### PR TITLE
[clang][DFP] Add support for -fexperimental-decimal-floating-point.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10232,8 +10232,8 @@ def ext_missing_type_specifier : ExtWarn<
   "implicit int">, InGroup<ImplicitInt>, DefaultError;
 def err_missing_type_specifier : Error<
   "a type specifier is required for all declarations">;
-def err_decimal_unsupported : Error<
-  "GNU decimal type extension not supported">;
+def err_dfp_disabled : Error<
+  "decimal floating-point extensions are not enabled">;
 def err_objc_array_of_interfaces : Error<
   "array of interface %0 is invalid (probably should be an array of pointers)">;
 def ext_c99_array_usage : Extension<

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -427,6 +427,9 @@ LANGOPT(FixedPoint, 1, 0, "fixed point types")
 LANGOPT(PaddingOnUnsignedFixedPoint, 1, 0,
         "unsigned fixed point types having one extra padding bit")
 
+// ISO/IEC TS 18661-2, ISO/IEC TR 24733, and C23 decimal floating-point.
+LANGOPT(DecimalFloatingPoint, 1, 0, "decimal floating-point extensions")
+
 LANGOPT(RegisterStaticDestructors, 1, 1, "Register C++ static destructors")
 
 LANGOPT(RegCall4, 1, 0, "Set __regcall4 as a default calling convention to respect __regcall ABI v.4")

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -428,9 +428,9 @@ KEYWORD(_Fract                      , KEYNOCXX)
 KEYWORD(_Sat                        , KEYNOCXX)
 
 // ISO/IEC TS 18661-2, ISO/IEC TR 24733, and C23 decimal floating-point.
-KEYWORD(_Decimal32                  , KEYALL)
-KEYWORD(_Decimal64                  , KEYALL)
-KEYWORD(_Decimal128                 , KEYALL)
+KEYWORD(_Decimal32                  , KEYNOCXX)
+KEYWORD(_Decimal64                  , KEYNOCXX)
+KEYWORD(_Decimal128                 , KEYNOCXX)
 
 // GNU Extensions (in impl-reserved namespace)
 KEYWORD(__null                      , KEYCXX)

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2055,6 +2055,11 @@ defm fixed_point : BoolFOption<"fixed-point",
   PosFlag<SetTrue, [], [ClangOption, CC1Option], "Enable">,
   NegFlag<SetFalse, [], [ClangOption], "Disable">,
   BothFlags<[], [ClangOption], " fixed point types">>, ShouldParseIf<!strconcat("!", cplusplus.KeyPath)>;
+defm decimal_floating_point : BoolFOption<"experimental-decimal-floating-point",
+  LangOpts<"DecimalFloatingPoint">, DefaultFalse,
+  PosFlag<SetTrue, [], [ClangOption, CC1Option], "Enable">,
+  NegFlag<SetFalse, [], [ClangOption], "Disable">,
+  BothFlags<[], [ClangOption], " decimal floating-point extensions">>;
 defm cxx_static_destructors : BoolFOption<"c++-static-destructors",
   LangOpts<"RegisterStaticDestructors">, DefaultTrue,
   NegFlag<SetFalse, [], [ClangOption, CC1Option],

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6004,6 +6004,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   Args.addOptInFlag(CmdArgs, options::OPT_ffixed_point,
                     options::OPT_fno_fixed_point);
 
+  Args.addOptInFlag(CmdArgs, options::OPT_fdecimal_floating_point,
+                    options::OPT_fno_decimal_floating_point);
+
   if (Arg *A = Args.getLastArg(options::OPT_fcxx_abi_EQ))
     A->render(Args, CmdArgs);
 

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -498,6 +498,12 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
   Builder.defineMacro("__STDC_UTF_16__", "1");
   Builder.defineMacro("__STDC_UTF_32__", "1");
 
+  // C23 decimal floating point extensions.
+  // FIXME: Define to 202311L when support for C23 decimal floating point
+  // FIXME: extensions is feature complete.
+  if (!LangOpts.CPlusPlus && LangOpts.DecimalFloatingPoint)
+    Builder.defineMacro("__STDC_IEC_60559_DFP__", "197001L");
+
   if (LangOpts.ObjC)
     Builder.defineMacro("__OBJC__");
 

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -1588,9 +1588,13 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
   case DeclSpec::TST_decimal32:    // _Decimal32
   case DeclSpec::TST_decimal64:    // _Decimal64
   case DeclSpec::TST_decimal128:   // _Decimal128
-    S.Diag(DS.getTypeSpecTypeLoc(), diag::err_decimal_unsupported);
-    Result = TSTToDecimalFloatType(Context, DS.getTypeSpecType());
-    declarator.setInvalidType(true);
+    if (!S.getLangOpts().DecimalFloatingPoint) {
+      S.Diag(DS.getTypeSpecTypeLoc(), diag::err_dfp_disabled);
+      Result = Context.IntTy;
+      declarator.setInvalidType(true);
+    } else {
+      Result = TSTToDecimalFloatType(Context, DS.getTypeSpecType());
+    }
     break;
   case DeclSpec::TST_class:
   case DeclSpec::TST_enum:

--- a/clang/test/Driver/dfp-enablement-lang.c
+++ b/clang/test/Driver/dfp-enablement-lang.c
@@ -1,0 +1,23 @@
+// This test is intended to validate whether decimal floating-point (DFP)
+// extensions are enabled based on language standard and to ensure a proper
+// diagnostic is issued for any use of DFP features otherwise.
+
+// RUN: %clang -target x86_64-unknown-linux-gnu -std=c17 -fsyntax-only -Xclang -verify=dfp-off,c-dfp-off %s
+// RUN: %clang -target x86_64-unknown-linux-gnu -std=c17 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify %s
+// FIXME: Remove -fexperimental-decimal-floating-point once -std=c23 implies DFP enablement.
+// RUN: %clang -target x86_64-unknown-linux-gnu -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify %s
+// RUN: %clang -target x86_64-unknown-linux-gnu -std=c23 -fsyntax-only -fno-experimental-decimal-floating-point -Xclang -verify=dfp-off,c-dfp-off %s
+// RUN: %clang -target x86_64-unknown-linux-gnu -x c++ -std=c++23 -fsyntax-only -Xclang -verify=cxx,dfp-off %s
+// RUN: %clang -target x86_64-unknown-linux-gnu -x c++ -std=c++23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=cxx %s
+// FIXME: Remove -fexperimental-decimal-floating-point once -std=c++2c (or later) implies DFP enablement.
+// RUN: %clang -target x86_64-unknown-linux-gnu -x c++ -std=c++2c -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=cxx %s
+// RUN: %clang -target x86_64-unknown-linux-gnu -x c++ -std=c++2c -fsyntax-only -fno-experimental-decimal-floating-point -Xclang -verify=cxx,dfp-off %s
+
+// expected-no-diagnostics
+
+_Decimal32 d32;   // cxx-error {{unknown type name '_Decimal32'}} \
+                  // c-dfp-off-error {{decimal floating-point extensions are not enabled}}
+_Decimal64 d64;   // cxx-error {{unknown type name '_Decimal64'}} \
+                  // c-dfp-off-error {{decimal floating-point extensions are not enabled}}
+_Decimal128 d128; // cxx-error {{unknown type name '_Decimal128'}} \
+                  // c-dfp-off-error {{decimal floating-point extensions are not enabled}}

--- a/clang/test/Driver/dfp-enablement-lang.c
+++ b/clang/test/Driver/dfp-enablement-lang.c
@@ -15,6 +15,19 @@
 
 // expected-no-diagnostics
 
+#if defined(__cplusplus)
+  #if defined(__STDC_IEC_60559_DFP__)
+    #error __STDC_IEC_60559_DFP__ should never be defined for C++
+  #endif
+#else
+  #if !defined(__STDC_IEC_60559_DFP__)
+    // c-dfp-off-error@+1 {{__STDC_IEC_60559_DFP__ should be defined}}
+    #error __STDC_IEC_60559_DFP__ should be defined for C when DFP support is enabled
+  #elif __STDC_IEC_60559_DFP__ != 197001L
+    #error __STDC_IEC_60559_DFP__ has the wrong value
+  #endif
+#endif
+
 _Decimal32 d32;   // cxx-error {{unknown type name '_Decimal32'}} \
                   // c-dfp-off-error {{decimal floating-point extensions are not enabled}}
 _Decimal64 d64;   // cxx-error {{unknown type name '_Decimal64'}} \

--- a/clang/test/Sema/dfp-types.c
+++ b/clang/test/Sema/dfp-types.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c23 -fexperimental-decimal-floating-point -fsyntax-only -verify=c %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x c++ -std=c++2c -fexperimental-decimal-floating-point -fsyntax-only -verify=cxx %s
+
+// c-no-diagnostics
+
+// _Decimal32, _Decimal64, and _Decimal128 are never keywords in C++.
+_Decimal32 d32; // cxx-error {{unknown type name '_Decimal32'}}
+_Decimal64 d64; // cxx-error {{unknown type name '_Decimal64'}}
+_Decimal128 d28; // cxx-error {{unknown type name '_Decimal128'}}

--- a/clang/test/Sema/types.c
+++ b/clang/test/Sema/types.c
@@ -48,9 +48,9 @@ enum e { e_1 };
 extern int j[sizeof(enum e)];  // expected-note {{previous declaration}}
 int j[42];   // expected-error {{redefinition of 'j' with a different type: 'int[42]' vs 'int[4]'}}
 
-_Decimal32 d32; // expected-error {{GNU decimal type extension not supported}}
-_Decimal64 d64; // expected-error {{GNU decimal type extension not supported}}
-_Decimal128 d128; // expected-error {{GNU decimal type extension not supported}}
+_Decimal32 d32; // expected-error {{decimal floating-point extensions are not enabled}}
+_Decimal64 d64; // expected-error {{decimal floating-point extensions are not enabled}}
+_Decimal128 d128; // expected-error {{decimal floating-point extensions are not enabled}}
 
 int __attribute__ ((vector_size (8), vector_size (8))) v;  // expected-error {{invalid vector element type}}
 


### PR DESCRIPTION
Though the ISO/IEC TS 18661-2:2015 decimal floating-point (DFP) extension has been adopted for the upcoming C23 standard, it will remain necessary to be able to explicitly enable and disable support for the extension for the foreseeable future for use with previous C standards and with C++. This change adds a driver and cc1 option to enable language support. Since support for the feature is not yet complete, the option name explicitly reflects its status as experimental and only serves to enable testing at this point.

No target considerations have been implemented yet. The option only serves to enable the _Decimal32, _Decimal64, and _Decimal128 keywords to be used as DFP type specifiers in C; these keywords are not enabled for C++ since, per ISO/IEC TR 24733:2011 and the gcc implementation, DFP support in C++ is provided via standard library types (that are expected to wrap a builtin type exposed by other means).