### PR TITLE
[clang][DFP] Enable target dependent support for decimal floating-point extensions.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10234,6 +10234,8 @@ def err_missing_type_specifier : Error<
   "a type specifier is required for all declarations">;
 def err_dfp_disabled : Error<
   "decimal floating-point extensions are not enabled">;
+def err_dfp_not_supported : Error<
+  "decimal floating-point extensions are not supported on the current target">;
 def err_objc_array_of_interfaces : Error<
   "array of interface %0 is invalid (probably should be an array of pointers)">;
 def ext_c99_array_usage : Extension<

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -220,6 +220,15 @@ enum OpenCLTypeKind : uint8_t {
   OCLTK_Sampler,
 };
 
+// ISO/IEC TS 18661-2, ISO/IEC TR 24733, and C23 decimal floating-point.
+// Multiple encodings for how Decimal floating-point values are stored are
+// used in practice. This enumeration provides an enumerator for each known
+// encoding.
+enum class DecimalFloatMode : uint8_t {
+  BID,  // Binary Integer Decimal.
+  DPD,  // Densely Packed Decimal.
+};
+
 /// Exposes information about the current target.
 ///
 class TargetInfo : public TransferrableTargetInfo,
@@ -277,6 +286,10 @@ protected:
   unsigned MaxOpenCLWorkGroupSize;
 
   std::optional<unsigned> MaxBitIntWidth;
+
+  // If disengaged, decimal floating-point extensions are not supported,
+  // otherwise, the decimal floating-point mode that is enabled.
+  std::optional<DecimalFloatMode> DecimalFloatEnablementAndMode;
 
   std::optional<llvm::Triple> DarwinTargetVariantTriple;
 
@@ -709,6 +722,20 @@ public:
 
   /// Determine whether constrained floating point is supported on this target.
   virtual bool hasStrictFP() const { return HasStrictFP; }
+
+  /// Determine whether decimal floating-point extensions are enabled on this
+  /// target.
+  bool hasDecimalFloatingPoint() const {
+    return DecimalFloatEnablementAndMode.has_value();
+  }
+
+  /// Determine the encoding used for decimal floating-point values on this
+  /// target if decimal floating-point extensions are enabled.
+  DecimalFloatMode getDecimalFloatingPointMode() const {
+    assert(hasDecimalFloatingPoint() &&
+           "Decimal floating-point extensions are not enabled");
+    return DecimalFloatEnablementAndMode.value();
+  }
 
   /// Return the alignment that is the largest alignment ever used for any
   /// scalar/SIMD data type on the target machine you are compiling for

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -221,9 +221,9 @@ enum OpenCLTypeKind : uint8_t {
 };
 
 // ISO/IEC TS 18661-2, ISO/IEC TR 24733, and C23 decimal floating-point.
-// Multiple encodings for how decimal floating-point values are stored are
-// used in practice. This enumeration provides an enumerator for each known
-// encoding.
+// Multiple encoding forms for the storage of decimal floating-point values
+// have been defined for use on various platforms. This enumeration provides
+// an enumerator for each known encoding.
 enum class DecimalFloatMode : uint8_t {
   BID,  // Binary Integer Decimal.
   DPD,  // Densely Packed Decimal.

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -221,7 +221,7 @@ enum OpenCLTypeKind : uint8_t {
 };
 
 // ISO/IEC TS 18661-2, ISO/IEC TR 24733, and C23 decimal floating-point.
-// Multiple encodings for how Decimal floating-point values are stored are
+// Multiple encodings for how decimal floating-point values are stored are
 // used in practice. This enumeration provides an enumerator for each known
 // encoding.
 enum class DecimalFloatMode : uint8_t {

--- a/clang/lib/Basic/TargetInfo.cpp
+++ b/clang/lib/Basic/TargetInfo.cpp
@@ -524,6 +524,12 @@ void TargetInfo::adjust(DiagnosticsEngine &Diags, LangOptions &Opts) {
 
   if (Opts.FakeAddressSpaceMap)
     AddrSpaceMap = &FakeAddrSpaceMap;
+
+  // If decimal floating-point extensions are not enabled at the language
+  // level, reset the target dependent DFP mode configuration in order to
+  // avoid surprises.
+  if (!Opts.DecimalFloatingPoint)
+    DecimalFloatEnablementAndMode.reset();
 }
 
 bool TargetInfo::initFeatureMap(

--- a/clang/lib/Basic/Targets/OSTargets.h
+++ b/clang/lib/Basic/Targets/OSTargets.h
@@ -352,6 +352,8 @@ public:
     case llvm::Triple::x86:
     case llvm::Triple::x86_64:
       this->HasFloat128 = true;
+      if (!Triple.isAndroid())
+        this->DecimalFloatEnablementAndMode = DecimalFloatMode::BID;
       break;
     }
   }

--- a/clang/lib/Basic/Targets/OSTargets.h
+++ b/clang/lib/Basic/Targets/OSTargets.h
@@ -352,8 +352,12 @@ public:
     case llvm::Triple::x86:
     case llvm::Triple::x86_64:
       this->HasFloat128 = true;
-      if (!Triple.isAndroid())
+      if (!Triple.isAndroid()) {
+        // Android NDK r23 and later no longer provide libgcc. DFP support
+        // for Android is therefore not enabled by default pending the
+        // availability of a different DFP run-time library.
         this->DecimalFloatEnablementAndMode = DecimalFloatMode::BID;
+      }
       break;
     }
   }

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -501,7 +501,8 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
   // C23 decimal floating point extensions.
   // FIXME: Define to 202311L when support for C23 decimal floating point
   // FIXME: extensions is feature complete.
-  if (!LangOpts.CPlusPlus && LangOpts.DecimalFloatingPoint)
+  if (!LangOpts.CPlusPlus && LangOpts.DecimalFloatingPoint &&
+      TI.hasDecimalFloatingPoint())
     Builder.defineMacro("__STDC_IEC_60559_DFP__", "197001L");
 
   if (LangOpts.ObjC)

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -4865,6 +4865,10 @@ void Sema::AddModeAttr(Decl *D, const AttributeCommonInfo &CI,
       Diag(AttrLoc, diag::err_dfp_disabled);
       return;
     }
+    if (!Context.getTargetInfo().hasDecimalFloatingPoint()) {
+      Diag(AttrLoc, diag::err_dfp_not_supported);
+      return;
+    }
   }
 
   if (ComplexMode) {

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -1592,6 +1592,10 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
       S.Diag(DS.getTypeSpecTypeLoc(), diag::err_dfp_disabled);
       Result = Context.IntTy;
       declarator.setInvalidType(true);
+    } else if (!S.Context.getTargetInfo().hasDecimalFloatingPoint()) {
+      S.Diag(DS.getTypeSpecTypeLoc(), diag::err_dfp_not_supported);
+      Result = Context.IntTy;
+      declarator.setInvalidType(true);
     } else {
       Result = TSTToDecimalFloatType(Context, DS.getTypeSpecType());
     }

--- a/clang/test/Driver/dfp-enablement-target.c
+++ b/clang/test/Driver/dfp-enablement-target.c
@@ -1,0 +1,82 @@
+// This test is intended to validate whether decimal floating-point (DFP)
+// extensions are supported and workding for a given target and to ensure
+// that an appropriate diagnostic is issued when DFP features are used
+// otherwise.
+
+// FIXME: Remove all uses of -fexperimental-decimal-floating-point once -std=c23 implies DFP enablement.
+// RUN: %clang -target aarch64-unknown-freebsd       -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target aarch64-unknown-linux         -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target aarch64-unknown-linux-android -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target aarch64-unknown-windows-gnu   -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target aarch64-unknown-windows-msvc  -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target arm64-apple-darwin            -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target arm64-apple-ios               -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target arm64-apple-macos             -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target arm64-apple-tvos              -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target arm64-apple-watchos           -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target arm64-unknown-linux           -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target arm64-unknown-linux-android   -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target armv7-unknown-linux           -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target armv7-unknown-linux-android   -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target armv7-unknown-netbsd          -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target armv7-unknown-openbsd         -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target armv7-unknown-windows-gnu     -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target armv7-unknown-windows-msvc    -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target hexagon-unknown-linux         -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target i686-unknown-linux            -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify %s
+// RUN: %clang -target i686-unknown-linux-android    -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target i686-unknown-windows-gnu      -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target i686-unknown-windows-msvc     -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target loongarch32-unknown-linux     -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target loongarch64-unknown-linux     -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target m68k-unknown-linux            -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target mips-unknown-freebsd          -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target mips-unknown-linux            -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target mips64-unknown-freebsd        -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target mips64-unknown-linux          -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target powerpc64-ibm-aix             -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target powerpc64-unknown-linux       -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target powerpc-ibm-aix               -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target powerpc-unknown-linux         -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target riscv32-unknown-linux         -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target riscv64-unknown-freebsd       -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target riscv64-unknown-fuchsia       -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target riscv64-unknown-linux         -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target riscv64-unknown-openbsd       -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target s390x-ibm-linux               -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target s390x-ibm-zos                 -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target sparc-sun-solaris             -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target sparc-unknown-freebsd         -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target sparc-unknown-linux           -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target sparc-unknown-netbsd          -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target sparcv9-sun-solaris           -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target sparc64-unknown-freebsd       -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target sparc64-unknown-linux         -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target sparc64-unknown-netbsd        -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target x86_64-apple-darwin           -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target x86_64-apple-ios              -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target x86_64-apple-macos            -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target x86_64-apple-tvos             -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target x86_64-apple-watchos          -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target x86_64-unknown-freebsd        -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target x86_64-unknown-fuchsia        -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target x86_64-unknown-haiku          -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target x86_64-unknown-linux          -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify %s
+// RUN: %clang -target x86_64-unknown-netbsd         -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target x86_64-unknown-openbsd        -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target x86_64-unknown-windows-gnu    -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+// RUN: %clang -target x86_64-unknown-windows-msvc   -std=c23 -fsyntax-only -fexperimental-decimal-floating-point -Xclang -verify=unsupported %s
+
+// expected-no-diagnostics
+
+_Decimal32 d32;   // unsupported-error {{decimal floating-point extensions are not supported on the current target}}
+_Decimal64 d64;   // unsupported-error {{decimal floating-point extensions are not supported on the current target}}
+_Decimal128 d128; // unsupported-error {{decimal floating-point extensions are not supported on the current target}}
+
+typedef float __attribute__((mode(SD))) D32;  // unsupported-error {{decimal floating-point extensions are not supported on the current target}}
+typedef float __attribute__((mode(DD))) D64;  // unsupported-error {{decimal floating-point extensions are not supported on the current target}}
+typedef float __attribute__((mode(TD))) D128; // unsupported-error {{decimal floating-point extensions are not supported on the current target}}
+
+float __attribute__((mode(SD))) famsd; // unsupported-error {{decimal floating-point extensions are not supported on the current target}}
+float __attribute__((mode(DD))) famdd; // unsupported-error {{decimal floating-point extensions are not supported on the current target}}
+float __attribute__((mode(TD))) famtd; // unsupported-error {{decimal floating-point extensions are not supported on the current target}}

--- a/clang/test/Driver/dfp-enablement-target.c
+++ b/clang/test/Driver/dfp-enablement-target.c
@@ -1,5 +1,5 @@
 // This test is intended to validate whether decimal floating-point (DFP)
-// extensions are supported and workding for a given target and to ensure
+// extensions are supported and working for a given target and to ensure
 // that an appropriate diagnostic is issued when DFP features are used
 // otherwise.
 


### PR DESCRIPTION
Support for decimal floating-point (DFP) extensions will, for most targets, require run-time library support that, for many targets, is
not yet available. This change adds basic infrastructure support to enable DFP support to be conditional on the target.

Some targets support more than one possible encoding of DFP values. It is therefore necessary for a target to not just indicate that
DFP support is available, but also the encoding to be used. This change recognizes the two known encodings that are used in practice and ties DFP enablement to the selection of one of these modes. The known encodings are:
- BID: Binary Integer Decimal
- DPD: Densely Packed Decimal