### PR TITLE
[llvm] [DFP] Add support for decimal floating point IR types.

### DIFF
--- a/clang/lib/CodeGen/CodeGenTypes.cpp
+++ b/clang/lib/CodeGen/CodeGenTypes.cpp
@@ -419,10 +419,13 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
       break;
 
     case BuiltinType::DecimalFloat32:
+      ResultType = llvm::Type::getDecimal32Ty(getLLVMContext());
+      break;
     case BuiltinType::DecimalFloat64:
+      ResultType = llvm::Type::getDecimal64Ty(getLLVMContext());
+      break;
     case BuiltinType::DecimalFloat128:
-      llvm::report_fatal_error("LLVM type support for decimal floating point "
-                               "is not yet implemented");
+      ResultType = llvm::Type::getDecimal128Ty(getLLVMContext());
       break;
 
     case BuiltinType::NullPtr:

--- a/llvm/docs/BitCodeFormat.rst
+++ b/llvm/docs/BitCodeFormat.rst
@@ -1361,7 +1361,7 @@ The operand fields are
 .. _CONSTANTS_BLOCK:
 
 TYPE_CODE_DECIMAL32 Record
-^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``[DECIMAL32]``
 
@@ -1369,7 +1369,7 @@ The ``DECIMAL32`` record (code 27) adds a ``decimal32`` (32-bit
 decimal floating point) type to the type table.
 
 TYPE_CODE_DECIMAL64 Record
-^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``[DECIMAL64]``
 
@@ -1377,7 +1377,7 @@ The ``DECIMAL64`` record (code 28) adds a ``decimal64`` (64-bit
 decimal floating point) type to the type table.
 
 TYPE_CODE_DECIMAL128 Record
-^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``[DECIMAL128]``
 

--- a/llvm/docs/BitCodeFormat.rst
+++ b/llvm/docs/BitCodeFormat.rst
@@ -1360,6 +1360,30 @@ The operand fields are
 
 .. _CONSTANTS_BLOCK:
 
+TYPE_CODE_DECIMAL32 Record
+^^^^^^^^^^^^^^^^^^^^^^
+
+``[DECIMAL32]``
+
+The ``DECIMAL32`` record (code 27) adds a ``decimal32`` (32-bit
+decimal floating point) type to the type table.
+
+TYPE_CODE_DECIMAL64 Record
+^^^^^^^^^^^^^^^^^^^^^^
+
+``[DECIMAL64]``
+
+The ``DECIMAL64`` record (code 28) adds a ``decimal64`` (64-bit
+decimal floating point) type to the type table.
+
+TYPE_CODE_DECIMAL128 Record
+^^^^^^^^^^^^^^^^^^^^^^
+
+``[DECIMAL128]``
+
+The ``DECIMAL128`` record (code 29) adds a ``decimal128`` (128-bit
+decimal floating point) type to the type table.
+
 CONSTANTS_BLOCK Contents
 ------------------------
 

--- a/llvm/docs/BitCodeFormat.rst
+++ b/llvm/docs/BitCodeFormat.rst
@@ -1358,8 +1358,6 @@ The operand fields are
 
 * *int_params*: Numbers that correspond to the integer parameters.
 
-.. _CONSTANTS_BLOCK:
-
 TYPE_CODE_DECIMAL32 Record
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -1383,6 +1381,8 @@ TYPE_CODE_DECIMAL128 Record
 
 The ``DECIMAL128`` record (code 29) adds a ``decimal128`` (128-bit
 decimal floating point) type to the type table.
+
+.. _CONSTANTS_BLOCK:
 
 CONSTANTS_BLOCK Contents
 ------------------------

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -3660,8 +3660,14 @@ Floating-Point Types
    * - ``float``
      - 32-bit floating-point value
 
+   * - ``decimal32``
+     - 32-bit decimal floating-point value
+
    * - ``double``
      - 64-bit floating-point value
+
+   * - ``decimal64``
+     - 64-bit decimal floating-point value
 
    * - ``fp128``
      - 128-bit floating-point value (113-bit significand)
@@ -3671,6 +3677,9 @@ Floating-Point Types
 
    * - ``ppc_fp128``
      - 128-bit floating-point value (two 64-bits)
+
+   * - ``decimal128``
+     - 128-bit decimal floating-point value
 
 The binary format of half, float, double, and fp128 correspond to the
 IEEE-754-2008 specifications for binary16, binary32, binary64, and binary128

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -3660,14 +3660,8 @@ Floating-Point Types
    * - ``float``
      - 32-bit floating-point value
 
-   * - ``decimal32``
-     - 32-bit decimal floating-point value
-
    * - ``double``
      - 64-bit floating-point value
-
-   * - ``decimal64``
-     - 64-bit decimal floating-point value
 
    * - ``fp128``
      - 128-bit floating-point value (113-bit significand)
@@ -3677,6 +3671,12 @@ Floating-Point Types
 
    * - ``ppc_fp128``
      - 128-bit floating-point value (two 64-bits)
+
+   * - ``decimal32``
+     - 32-bit decimal floating-point value
+
+   * - ``decimal64``
+     - 64-bit decimal floating-point value
 
    * - ``decimal128``
      - 128-bit decimal floating-point value

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -149,10 +149,13 @@ typedef enum {
   LLVMVoidTypeKind,      /**< type with no size */
   LLVMHalfTypeKind,      /**< 16 bit floating point type */
   LLVMFloatTypeKind,     /**< 32 bit floating point type */
+  LLVMDecimal32TypeKind, /**< 32 bit decimal floating point type */
   LLVMDoubleTypeKind,    /**< 64 bit floating point type */
+  LLVMDecimal64TypeKind, /**< 64 bit decimal floating point type */
   LLVMX86_FP80TypeKind,  /**< 80 bit floating point type (X87) */
   LLVMFP128TypeKind,     /**< 128 bit floating point type (112-bit mantissa)*/
   LLVMPPC_FP128TypeKind, /**< 128 bit floating point type (two 64-bits) */
+  LLVMDecimal128TypeKind,/**< 128 bit decimal floating point type */
   LLVMLabelTypeKind,     /**< Labels */
   LLVMIntegerTypeKind,   /**< Arbitrary bit width integers */
   LLVMFunctionTypeKind,  /**< Functions */
@@ -1270,9 +1273,19 @@ LLVMTypeRef LLVMBFloatTypeInContext(LLVMContextRef C);
 LLVMTypeRef LLVMFloatTypeInContext(LLVMContextRef C);
 
 /**
+ * Obtain a 32-bit decimal floating point type from a context.
+ */
+LLVMTypeRef LLVMDecimal32TypeInContext(LLVMContextRef C);
+
+/**
  * Obtain a 64-bit floating point type from a context.
  */
 LLVMTypeRef LLVMDoubleTypeInContext(LLVMContextRef C);
+
+/**
+ * Obtain a 64-bit decimal floating point type from a context.
+ */
+LLVMTypeRef LLVMDecimal64TypeInContext(LLVMContextRef C);
 
 /**
  * Obtain a 80-bit floating point type (X87) from a context.
@@ -1291,6 +1304,11 @@ LLVMTypeRef LLVMFP128TypeInContext(LLVMContextRef C);
 LLVMTypeRef LLVMPPCFP128TypeInContext(LLVMContextRef C);
 
 /**
+ * Obtain a 128-bit decimal floating point type from a context.
+ */
+LLVMTypeRef LLVMDecimal128TypeInContext(LLVMContextRef C);
+
+/**
  * Obtain a floating point type from the global context.
  *
  * These map to the functions in this group of the same name.
@@ -1298,10 +1316,13 @@ LLVMTypeRef LLVMPPCFP128TypeInContext(LLVMContextRef C);
 LLVMTypeRef LLVMHalfType(void);
 LLVMTypeRef LLVMBFloatType(void);
 LLVMTypeRef LLVMFloatType(void);
+LLVMTypeRef LLVMDecimal32Type(void);
 LLVMTypeRef LLVMDoubleType(void);
+LLVMTypeRef LLVMDecimal64Type(void);
 LLVMTypeRef LLVMX86FP80Type(void);
 LLVMTypeRef LLVMFP128Type(void);
 LLVMTypeRef LLVMPPCFP128Type(void);
+LLVMTypeRef LLVMDecimal128Type(void);
 
 /**
  * @}

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -1316,12 +1316,12 @@ LLVMTypeRef LLVMDecimal128TypeInContext(LLVMContextRef C);
 LLVMTypeRef LLVMHalfType(void);
 LLVMTypeRef LLVMBFloatType(void);
 LLVMTypeRef LLVMFloatType(void);
-LLVMTypeRef LLVMDecimal32Type(void);
 LLVMTypeRef LLVMDoubleType(void);
-LLVMTypeRef LLVMDecimal64Type(void);
 LLVMTypeRef LLVMX86FP80Type(void);
 LLVMTypeRef LLVMFP128Type(void);
 LLVMTypeRef LLVMPPCFP128Type(void);
+LLVMTypeRef LLVMDecimal32Type(void);
+LLVMTypeRef LLVMDecimal64Type(void);
 LLVMTypeRef LLVMDecimal128Type(void);
 
 /**

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -149,13 +149,10 @@ typedef enum {
   LLVMVoidTypeKind,      /**< type with no size */
   LLVMHalfTypeKind,      /**< 16 bit floating point type */
   LLVMFloatTypeKind,     /**< 32 bit floating point type */
-  LLVMDecimal32TypeKind, /**< 32 bit decimal floating point type */
   LLVMDoubleTypeKind,    /**< 64 bit floating point type */
-  LLVMDecimal64TypeKind, /**< 64 bit decimal floating point type */
   LLVMX86_FP80TypeKind,  /**< 80 bit floating point type (X87) */
   LLVMFP128TypeKind,     /**< 128 bit floating point type (112-bit mantissa)*/
   LLVMPPC_FP128TypeKind, /**< 128 bit floating point type (two 64-bits) */
-  LLVMDecimal128TypeKind,/**< 128 bit decimal floating point type */
   LLVMLabelTypeKind,     /**< Labels */
   LLVMIntegerTypeKind,   /**< Arbitrary bit width integers */
   LLVMFunctionTypeKind,  /**< Functions */
@@ -167,9 +164,12 @@ typedef enum {
   LLVMX86_MMXTypeKind,   /**< X86 MMX */
   LLVMTokenTypeKind,     /**< Tokens */
   LLVMScalableVectorTypeKind, /**< Scalable SIMD vector type */
-  LLVMBFloatTypeKind,    /**< 16 bit brain floating point type */
-  LLVMX86_AMXTypeKind,   /**< X86 AMX */
-  LLVMTargetExtTypeKind, /**< Target extension type */
+  LLVMBFloatTypeKind,         /**< 16 bit brain floating point type */
+  LLVMX86_AMXTypeKind,        /**< X86 AMX */
+  LLVMTargetExtTypeKind,      /**< Target extension type */
+  LLVMDecimal32TypeKind,      /**< 32 bit decimal floating point type */
+  LLVMDecimal64TypeKind,      /**< 64 bit decimal floating point type */
+  LLVMDecimal128TypeKind,     /**< 128 bit decimal floating point type */
 } LLVMTypeKind;
 
 typedef enum {
@@ -1273,19 +1273,9 @@ LLVMTypeRef LLVMBFloatTypeInContext(LLVMContextRef C);
 LLVMTypeRef LLVMFloatTypeInContext(LLVMContextRef C);
 
 /**
- * Obtain a 32-bit decimal floating point type from a context.
- */
-LLVMTypeRef LLVMDecimal32TypeInContext(LLVMContextRef C);
-
-/**
  * Obtain a 64-bit floating point type from a context.
  */
 LLVMTypeRef LLVMDoubleTypeInContext(LLVMContextRef C);
-
-/**
- * Obtain a 64-bit decimal floating point type from a context.
- */
-LLVMTypeRef LLVMDecimal64TypeInContext(LLVMContextRef C);
 
 /**
  * Obtain a 80-bit floating point type (X87) from a context.
@@ -1302,6 +1292,16 @@ LLVMTypeRef LLVMFP128TypeInContext(LLVMContextRef C);
  * Obtain a 128-bit floating point type (two 64-bits) from a context.
  */
 LLVMTypeRef LLVMPPCFP128TypeInContext(LLVMContextRef C);
+
+/**
+ * Obtain a 32-bit decimal floating point type from a context.
+ */
+LLVMTypeRef LLVMDecimal32TypeInContext(LLVMContextRef C);
+
+/**
+ * Obtain a 64-bit decimal floating point type from a context.
+ */
+LLVMTypeRef LLVMDecimal64TypeInContext(LLVMContextRef C);
 
 /**
  * Obtain a 128-bit decimal floating point type from a context.

--- a/llvm/include/llvm/Bitcode/LLVMBitCodes.h
+++ b/llvm/include/llvm/Bitcode/LLVMBitCodes.h
@@ -177,6 +177,10 @@ enum TypeCodes {
   TYPE_CODE_OPAQUE_POINTER = 25, // OPAQUE_POINTER: [addrspace]
 
   TYPE_CODE_TARGET_TYPE = 26, // TARGET_TYPE
+
+  TYPE_CODE_DECIMAL32 = 27,  // 32-bit decimal floating point
+  TYPE_CODE_DECIMAL64 = 28,  // 64-bit decimal floating point
+  TYPE_CODE_DECIMAL128 = 29  // 128-bit decimal floating point
 };
 
 enum OperandBundleTagCode {

--- a/llvm/include/llvm/IR/DataLayout.h
+++ b/llvm/include/llvm/IR/DataLayout.h
@@ -690,12 +690,15 @@ inline TypeSize DataLayout::getTypeSizeInBits(Type *Ty) const {
   case Type::BFloatTyID:
     return TypeSize::Fixed(16);
   case Type::FloatTyID:
+  case Type::Decimal32TyID:
     return TypeSize::Fixed(32);
   case Type::DoubleTyID:
   case Type::X86_MMXTyID:
+  case Type::Decimal64TyID:
     return TypeSize::Fixed(64);
   case Type::PPC_FP128TyID:
   case Type::FP128TyID:
+  case Type::Decimal128TyID:
     return TypeSize::Fixed(128);
   case Type::X86_AMXTyID:
     return TypeSize::Fixed(8192);

--- a/llvm/include/llvm/IR/DataLayout.h
+++ b/llvm/include/llvm/IR/DataLayout.h
@@ -690,15 +690,12 @@ inline TypeSize DataLayout::getTypeSizeInBits(Type *Ty) const {
   case Type::BFloatTyID:
     return TypeSize::Fixed(16);
   case Type::FloatTyID:
-  case Type::Decimal32TyID:
     return TypeSize::Fixed(32);
   case Type::DoubleTyID:
   case Type::X86_MMXTyID:
-  case Type::Decimal64TyID:
     return TypeSize::Fixed(64);
   case Type::PPC_FP128TyID:
   case Type::FP128TyID:
-  case Type::Decimal128TyID:
     return TypeSize::Fixed(128);
   case Type::X86_AMXTyID:
     return TypeSize::Fixed(8192);
@@ -718,6 +715,12 @@ inline TypeSize DataLayout::getTypeSizeInBits(Type *Ty) const {
     Type *LayoutTy = cast<TargetExtType>(Ty)->getLayoutType();
     return getTypeSizeInBits(LayoutTy);
   }
+  case Type::Decimal32TyID:
+    return TypeSize::Fixed(32);
+  case Type::Decimal64TyID:
+    return TypeSize::Fixed(64);
+  case Type::Decimal128TyID:
+    return TypeSize::Fixed(128);
   default:
     llvm_unreachable("DataLayout::getTypeSizeInBits(): Unsupported type");
   }

--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -541,9 +541,24 @@ public:
     return Type::getFloatTy(Context);
   }
 
+  /// Fetch the type representing a 32-bit decimal floating point value.
+  Type *getDecimal32Ty() {
+    return Type::getDecimal32Ty(Context);
+  }
+
   /// Fetch the type representing a 64-bit floating point value.
   Type *getDoubleTy() {
     return Type::getDoubleTy(Context);
+  }
+
+  /// Fetch the type representing a 64-bit decimal floating point value.
+  Type *getDecimal64Ty() {
+    return Type::getDecimal64Ty(Context);
+  }
+
+  /// Fetch the type representing a 128-bit decimal floating point value.
+  Type *getDecimal128Ty() {
+    return Type::getDecimal128Ty(Context);
   }
 
   /// Fetch the type representing void.

--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -541,14 +541,14 @@ public:
     return Type::getFloatTy(Context);
   }
 
-  /// Fetch the type representing a 32-bit decimal floating point value.
-  Type *getDecimal32Ty() {
-    return Type::getDecimal32Ty(Context);
-  }
-
   /// Fetch the type representing a 64-bit floating point value.
   Type *getDoubleTy() {
     return Type::getDoubleTy(Context);
+  }
+
+  /// Fetch the type representing a 32-bit decimal floating point value.
+  Type *getDecimal32Ty() {
+    return Type::getDecimal32Ty(Context);
   }
 
   /// Fetch the type representing a 64-bit decimal floating point value.

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -56,10 +56,13 @@ public:
     HalfTyID = 0,  ///< 16-bit floating point type
     BFloatTyID,    ///< 16-bit floating point type (7-bit significand)
     FloatTyID,     ///< 32-bit floating point type
+    Decimal32TyID, ///< 32-bit decimal floating point type
     DoubleTyID,    ///< 64-bit floating point type
+    Decimal64TyID, ///< 64-bit decimal floating point type
     X86_FP80TyID,  ///< 80-bit floating point type (X87)
     FP128TyID,     ///< 128-bit floating point type (112-bit significand)
     PPC_FP128TyID, ///< 128-bit floating point type (two 64-bits, PowerPC)
+    Decimal128TyID,///< 128-bit decimal floating point type
     VoidTyID,      ///< type with no size
     LabelTyID,     ///< Labels
     MetadataTyID,  ///< Metadata
@@ -165,6 +168,15 @@ public:
   /// Return true if this is powerpc long double.
   bool isPPC_FP128Ty() const { return getTypeID() == PPC_FP128TyID; }
 
+  /// Return true if this is 'decimal32'.
+  bool isDecimal32Ty() const { return getTypeID() == Decimal32TyID; }
+
+  /// Return true if this is 'decimal64'.
+  bool isDecimal64Ty() const { return getTypeID() == Decimal64TyID; }
+
+  /// Return true if this is 'decimal128'.
+  bool isDecimal128Ty() const { return getTypeID() == Decimal128TyID; }
+
   /// Return true if this is a well-behaved IEEE-like type, which has a IEEE
   /// compatible layout as defined by isIEEE(), and does not have unnormal
   /// values
@@ -175,6 +187,9 @@ public:
     case HalfTyID:
     case BFloatTyID:
     case FP128TyID:
+    case Decimal32TyID:
+    case Decimal64TyID:
+    case Decimal128TyID:
       return true;
     default:
       return false;
@@ -448,11 +463,14 @@ public:
   static Type *getHalfTy(LLVMContext &C);
   static Type *getBFloatTy(LLVMContext &C);
   static Type *getFloatTy(LLVMContext &C);
+  static Type *getDecimal32Ty(LLVMContext &C);
   static Type *getDoubleTy(LLVMContext &C);
+  static Type *getDecimal64Ty(LLVMContext &C);
   static Type *getMetadataTy(LLVMContext &C);
   static Type *getX86_FP80Ty(LLVMContext &C);
   static Type *getFP128Ty(LLVMContext &C);
   static Type *getPPC_FP128Ty(LLVMContext &C);
+  static Type *getDecimal128Ty(LLVMContext &C);
   static Type *getX86_MMXTy(LLVMContext &C);
   static Type *getX86_AMXTy(LLVMContext &C);
   static Type *getTokenTy(LLVMContext &C);

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -57,12 +57,12 @@ public:
     BFloatTyID,    ///< 16-bit floating point type (7-bit significand)
     Decimal32TyID, ///< 32-bit decimal floating point type
     FloatTyID,     ///< 32-bit floating point type
-    DoubleTyID,    ///< 64-bit floating point type
     Decimal64TyID, ///< 64-bit decimal floating point type
+    DoubleTyID,    ///< 64-bit floating point type
     X86_FP80TyID,  ///< 80-bit floating point type (X87)
+    Decimal128TyID, ///< 128-bit decimal floating point type
     FP128TyID,     ///< 128-bit floating point type (112-bit significand)
     PPC_FP128TyID, ///< 128-bit floating point type (two 64-bits, PowerPC)
-    Decimal128TyID,///< 128-bit decimal floating point type
     VoidTyID,      ///< type with no size
     LabelTyID,     ///< Labels
     MetadataTyID,  ///< Metadata

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -177,6 +177,12 @@ public:
   /// Return true if this is 'decimal128'.
   bool isDecimal128Ty() const { return getTypeID() == Decimal128TyID; }
 
+  /// Return true if this is a decimal floating point.
+  bool isDecimalFPTy() const {
+    return getTypeID() == Decimal32TyID || getTypeID() == Decimal64TyID ||
+           getTypeID() == Decimal128TyID;
+  }
+
   /// Return true if this is a well-behaved IEEE-like type, which has a IEEE
   /// compatible layout as defined by isIEEE(), and does not have unnormal
   /// values
@@ -187,9 +193,6 @@ public:
     case HalfTyID:
     case BFloatTyID:
     case FP128TyID:
-    case Decimal32TyID:
-    case Decimal64TyID:
-    case Decimal128TyID:
       return true;
     default:
       return false;
@@ -199,7 +202,7 @@ public:
   /// Return true if this is one of the floating-point types
   bool isFloatingPointTy() const {
     return isIEEELikeFPTy() || getTypeID() == X86_FP80TyID ||
-           getTypeID() == PPC_FP128TyID;
+           getTypeID() == PPC_FP128TyID || isDecimalFPTy();
   }
 
   /// Returns true if this is a floating-point type that is an unevaluated sum
@@ -351,7 +354,8 @@ public:
 
   /// Return the width of the mantissa of this type. This is only valid on
   /// floating-point types. If the FP type does not have a stable mantissa (e.g.
-  /// ppc long double), this method returns -1.
+  /// ppc long double), or if the type is a decimal floating point this method
+  /// returns -1.
   int getFPMantissaWidth() const;
 
   /// Return whether the type is IEEE compatible, as defined by the eponymous

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -55,8 +55,8 @@ public:
     // PrimitiveTypes
     HalfTyID = 0,  ///< 16-bit floating point type
     BFloatTyID,    ///< 16-bit floating point type (7-bit significand)
-    FloatTyID,     ///< 32-bit floating point type
     Decimal32TyID, ///< 32-bit decimal floating point type
+    FloatTyID,     ///< 32-bit floating point type
     DoubleTyID,    ///< 64-bit floating point type
     Decimal64TyID, ///< 64-bit decimal floating point type
     X86_FP80TyID,  ///< 80-bit floating point type (X87)

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -359,8 +359,9 @@ public:
   /// (e.g. ppc long double), this method returns -1.
   int getFPMantissaWidth() const;
 
-  /// Return the width of the mantissa of a decimal floating-point type, in
-  /// digits. See table in section X.2.1 of WG14 N2601.
+  /// Return the precision in digits of a decimal floating-point type
+  /// per the "Decimal interchange format parameters" table of
+  /// C23 annex H.2.1, "Interchange floating types".
   int getDFPPrecisionInDigits() const;
 
   /// Return whether the type is IEEE compatible, as defined by the eponymous

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -55,12 +55,9 @@ public:
     // PrimitiveTypes
     HalfTyID = 0,  ///< 16-bit floating point type
     BFloatTyID,    ///< 16-bit floating point type (7-bit significand)
-    Decimal32TyID, ///< 32-bit decimal floating point type
     FloatTyID,     ///< 32-bit floating point type
-    Decimal64TyID, ///< 64-bit decimal floating point type
     DoubleTyID,    ///< 64-bit floating point type
     X86_FP80TyID,  ///< 80-bit floating point type (X87)
-    Decimal128TyID, ///< 128-bit decimal floating point type
     FP128TyID,     ///< 128-bit floating point type (112-bit significand)
     PPC_FP128TyID, ///< 128-bit floating point type (two 64-bits, PowerPC)
     VoidTyID,      ///< type with no size
@@ -69,6 +66,11 @@ public:
     X86_MMXTyID,   ///< MMX vectors (64 bits, X86 specific)
     X86_AMXTyID,   ///< AMX vectors (8192 bits, X86 specific)
     TokenTyID,     ///< Tokens
+
+    // Decimal floating-point types.
+    Decimal32TyID, ///< 32-bit decimal floating point type
+    Decimal64TyID, ///< 64-bit decimal floating point type
+    Decimal128TyID, ///< 128-bit decimal floating point type
 
     // Derived types... see DerivedTypes.h file.
     IntegerTyID,        ///< Arbitrary bit width integers
@@ -352,13 +354,14 @@ public:
   /// type.
   unsigned getScalarSizeInBits() const LLVM_READONLY;
 
-  /// Return the width of the mantissa of this type. This is only valid on
-  /// floating-point types. If the FP type does not have a stable mantissa (e.g.
-  /// ppc long double), this method returns -1.
+  /// Return the width of the mantissa of this type, in bits. This is only valid
+  /// on floating-point types. If the FP type does not have a stable mantissa
+  /// (e.g. ppc long double), this method returns -1.
   int getFPMantissaWidth() const;
 
-  /// Return the width of the mantissa of a decimal floating-point type.
-  int getDFPMantissaWidth() const;
+  /// Return the width of the mantissa of a decimal floating-point type, in
+  /// digits. See table in section X.2.1 of WG14 N2601.
+  int getDFPPrecisionInDigits() const;
 
   /// Return whether the type is IEEE compatible, as defined by the eponymous
   /// method in APFloat.

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -354,10 +354,10 @@ public:
 
   /// Return the width of the mantissa of this type. This is only valid on
   /// floating-point types. If the FP type does not have a stable mantissa (e.g.
-  /// ppc long double), or if the type is a decimal floating point this method
-  /// returns -1.
+  /// ppc long double), this method returns -1.
   int getFPMantissaWidth() const;
 
+  /// Return the width of the mantissa of a decimal floating-point type.
   int getDFPMantissaWidth() const;
 
   /// Return whether the type is IEEE compatible, as defined by the eponymous

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -178,7 +178,7 @@ public:
   bool isDecimal128Ty() const { return getTypeID() == Decimal128TyID; }
 
   /// Return true if this is a decimal floating point.
-  bool isDecimalFPTy() const {
+  bool isDecimalFloatingPointTy() const {
     return getTypeID() == Decimal32TyID || getTypeID() == Decimal64TyID ||
            getTypeID() == Decimal128TyID;
   }
@@ -202,7 +202,7 @@ public:
   /// Return true if this is one of the floating-point types
   bool isFloatingPointTy() const {
     return isIEEELikeFPTy() || getTypeID() == X86_FP80TyID ||
-           getTypeID() == PPC_FP128TyID || isDecimalFPTy();
+           getTypeID() == PPC_FP128TyID || isDecimalFloatingPointTy();
   }
 
   /// Returns true if this is a floating-point type that is an unevaluated sum
@@ -357,6 +357,8 @@ public:
   /// ppc long double), or if the type is a decimal floating point this method
   /// returns -1.
   int getFPMantissaWidth() const;
+
+  int getDFPMantissaWidth() const;
 
   /// Return whether the type is IEEE compatible, as defined by the eponymous
   /// method in APFloat.

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -469,14 +469,11 @@ public:
   static Type *getHalfTy(LLVMContext &C);
   static Type *getBFloatTy(LLVMContext &C);
   static Type *getFloatTy(LLVMContext &C);
-  static Type *getDecimal32Ty(LLVMContext &C);
   static Type *getDoubleTy(LLVMContext &C);
-  static Type *getDecimal64Ty(LLVMContext &C);
   static Type *getMetadataTy(LLVMContext &C);
   static Type *getX86_FP80Ty(LLVMContext &C);
   static Type *getFP128Ty(LLVMContext &C);
   static Type *getPPC_FP128Ty(LLVMContext &C);
-  static Type *getDecimal128Ty(LLVMContext &C);
   static Type *getX86_MMXTy(LLVMContext &C);
   static Type *getX86_AMXTy(LLVMContext &C);
   static Type *getTokenTy(LLVMContext &C);
@@ -487,6 +484,9 @@ public:
   static IntegerType *getInt32Ty(LLVMContext &C);
   static IntegerType *getInt64Ty(LLVMContext &C);
   static IntegerType *getInt128Ty(LLVMContext &C);
+  static Type *getDecimal32Ty(LLVMContext &C);
+  static Type *getDecimal64Ty(LLVMContext &C);
+  static Type *getDecimal128Ty(LLVMContext &C);
   template <typename ScalarTy> static Type *getScalarTy(LLVMContext &C) {
     int noOfBits = sizeof(ScalarTy) * CHAR_BIT;
     if (std::is_integral<ScalarTy>::value) {

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -816,10 +816,13 @@ lltok::Kind LLLexer::LexIdentifier() {
   TYPEKEYWORD("half",      Type::getHalfTy(Context));
   TYPEKEYWORD("bfloat",    Type::getBFloatTy(Context));
   TYPEKEYWORD("float",     Type::getFloatTy(Context));
+  TYPEKEYWORD("decimal32", Type::getDecimal32Ty(Context));
   TYPEKEYWORD("double",    Type::getDoubleTy(Context));
+  TYPEKEYWORD("decimal64", Type::getDecimal64Ty(Context));
   TYPEKEYWORD("x86_fp80",  Type::getX86_FP80Ty(Context));
   TYPEKEYWORD("fp128",     Type::getFP128Ty(Context));
   TYPEKEYWORD("ppc_fp128", Type::getPPC_FP128Ty(Context));
+  TYPEKEYWORD("decimal128", Type::getDecimal128Ty(Context));
   TYPEKEYWORD("label",     Type::getLabelTy(Context));
   TYPEKEYWORD("metadata",  Type::getMetadataTy(Context));
   TYPEKEYWORD("x86_mmx",   Type::getX86_MMXTy(Context));
@@ -984,6 +987,9 @@ lltok::Kind LLLexer::LexIdentifier() {
 ///    HexPPC128Constant 0xM[0-9A-Fa-f]+
 ///    HexHalfConstant   0xH[0-9A-Fa-f]+
 ///    HexBFloatConstant 0xR[0-9A-Fa-f]+
+///    HexDecimal32Constant 0xR[0-9A-Fa-f]+
+///    HexDecimal64Constant 0xR[0-9A-Fa-f]+
+///    HexDecimal128Constant 0xR[0-9A-Fa-f]+
 lltok::Kind LLLexer::Lex0x() {
   CurPtr = TokStart + 2;
 

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -990,7 +990,6 @@ lltok::Kind LLLexer::LexIdentifier() {
 lltok::Kind LLLexer::Lex0x() {
   CurPtr = TokStart + 2;
 
-  // TODO: Handle the DFP type here.
   char Kind;
   if ((CurPtr[0] >= 'K' && CurPtr[0] <= 'M') || CurPtr[0] == 'H' ||
       CurPtr[0] == 'R') {
@@ -1009,8 +1008,6 @@ lltok::Kind LLLexer::Lex0x() {
     ++CurPtr;
 
   if (Kind == 'J') {
-    // FIXME: Need to add code here for DFP, using the APDecimalFloat.
-
     // HexFPConstant - Floating point constant represented in IEEE format as a
     // hexadecimal number for when exponential notation is not precise enough.
     // Half, BFloat, Float, and double only.

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -816,19 +816,19 @@ lltok::Kind LLLexer::LexIdentifier() {
   TYPEKEYWORD("half",      Type::getHalfTy(Context));
   TYPEKEYWORD("bfloat",    Type::getBFloatTy(Context));
   TYPEKEYWORD("float",     Type::getFloatTy(Context));
-  TYPEKEYWORD("decimal32", Type::getDecimal32Ty(Context));
   TYPEKEYWORD("double",    Type::getDoubleTy(Context));
-  TYPEKEYWORD("decimal64", Type::getDecimal64Ty(Context));
   TYPEKEYWORD("x86_fp80",  Type::getX86_FP80Ty(Context));
   TYPEKEYWORD("fp128",     Type::getFP128Ty(Context));
   TYPEKEYWORD("ppc_fp128", Type::getPPC_FP128Ty(Context));
-  TYPEKEYWORD("decimal128", Type::getDecimal128Ty(Context));
   TYPEKEYWORD("label",     Type::getLabelTy(Context));
   TYPEKEYWORD("metadata",  Type::getMetadataTy(Context));
   TYPEKEYWORD("x86_mmx",   Type::getX86_MMXTy(Context));
   TYPEKEYWORD("x86_amx",   Type::getX86_AMXTy(Context));
   TYPEKEYWORD("token",     Type::getTokenTy(Context));
   TYPEKEYWORD("ptr",       PointerType::getUnqual(Context));
+  TYPEKEYWORD("decimal32", Type::getDecimal32Ty(Context));
+  TYPEKEYWORD("decimal64", Type::getDecimal64Ty(Context));
+  TYPEKEYWORD("decimal128", Type::getDecimal128Ty(Context));
 
 #undef TYPEKEYWORD
 

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -987,12 +987,16 @@ lltok::Kind LLLexer::LexIdentifier() {
 ///    HexPPC128Constant 0xM[0-9A-Fa-f]+
 ///    HexHalfConstant   0xH[0-9A-Fa-f]+
 ///    HexBFloatConstant 0xR[0-9A-Fa-f]+
-///    HexDecimal32Constant 0xR[0-9A-Fa-f]+
-///    HexDecimal64Constant 0xR[0-9A-Fa-f]+
-///    HexDecimal128Constant 0xR[0-9A-Fa-f]+
+///    FIXME: I have temporarily added these prefixes temporarly to mimic
+///    the DFP attributes in C++. But this is just a placeholder for
+///    the real prefix.
+///    HexDecimal32Constant 0xSD[0-9A-Fa-f]+
+///    HexDecimal64Constant 0xDD[0-9A-Fa-f]+
+///    HexDecimal128Constant 0xTD[0-9A-Fa-f]+
 lltok::Kind LLLexer::Lex0x() {
   CurPtr = TokStart + 2;
 
+  // TODO: Handle the DFP type here.
   char Kind;
   if ((CurPtr[0] >= 'K' && CurPtr[0] <= 'M') || CurPtr[0] == 'H' ||
       CurPtr[0] == 'R') {

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -987,12 +987,6 @@ lltok::Kind LLLexer::LexIdentifier() {
 ///    HexPPC128Constant 0xM[0-9A-Fa-f]+
 ///    HexHalfConstant   0xH[0-9A-Fa-f]+
 ///    HexBFloatConstant 0xR[0-9A-Fa-f]+
-///    FIXME: I have temporarily added these prefixes temporarly to mimic
-///    the DFP attributes in C++. But this is just a placeholder for
-///    the real prefix.
-///    HexDecimal32Constant 0xSD[0-9A-Fa-f]+
-///    HexDecimal64Constant 0xDD[0-9A-Fa-f]+
-///    HexDecimal128Constant 0xTD[0-9A-Fa-f]+
 lltok::Kind LLLexer::Lex0x() {
   CurPtr = TokStart + 2;
 
@@ -1015,6 +1009,8 @@ lltok::Kind LLLexer::Lex0x() {
     ++CurPtr;
 
   if (Kind == 'J') {
+    // FIXME: Need to add code here for DFP, using the APDecimalFloat.
+
     // HexFPConstant - Floating point constant represented in IEEE format as a
     // hexadecimal number for when exponential notation is not precise enough.
     // Half, BFloat, Float, and double only.

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -2306,8 +2306,14 @@ Error BitcodeReader::parseTypeTableBody() {
     case bitc::TYPE_CODE_FLOAT:     // FLOAT
       ResultTy = Type::getFloatTy(Context);
       break;
+    case bitc::TYPE_CODE_DECIMAL32: // 32-bit DFP
+      ResultTy = Type::getDecimal32Ty(Context);
+      break;
     case bitc::TYPE_CODE_DOUBLE:    // DOUBLE
       ResultTy = Type::getDoubleTy(Context);
+      break;
+    case bitc::TYPE_CODE_DECIMAL64: // 64-bit DFP
+      ResultTy = Type::getDecimal64Ty(Context);
       break;
     case bitc::TYPE_CODE_X86_FP80:  // X86_FP80
       ResultTy = Type::getX86_FP80Ty(Context);
@@ -2317,6 +2323,9 @@ Error BitcodeReader::parseTypeTableBody() {
       break;
     case bitc::TYPE_CODE_PPC_FP128: // PPC_FP128
       ResultTy = Type::getPPC_FP128Ty(Context);
+      break;
+    case bitc::TYPE_CODE_DECIMAL128: // 128-bit DFP
+      ResultTy = Type::getDecimal128Ty(Context);
       break;
     case bitc::TYPE_CODE_LABEL:     // LABEL
       ResultTy = Type::getLabelTy(Context);

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -2306,14 +2306,8 @@ Error BitcodeReader::parseTypeTableBody() {
     case bitc::TYPE_CODE_FLOAT:     // FLOAT
       ResultTy = Type::getFloatTy(Context);
       break;
-    case bitc::TYPE_CODE_DECIMAL32: // 32-bit DFP
-      ResultTy = Type::getDecimal32Ty(Context);
-      break;
     case bitc::TYPE_CODE_DOUBLE:    // DOUBLE
       ResultTy = Type::getDoubleTy(Context);
-      break;
-    case bitc::TYPE_CODE_DECIMAL64: // 64-bit DFP
-      ResultTy = Type::getDecimal64Ty(Context);
       break;
     case bitc::TYPE_CODE_X86_FP80:  // X86_FP80
       ResultTy = Type::getX86_FP80Ty(Context);
@@ -2323,9 +2317,6 @@ Error BitcodeReader::parseTypeTableBody() {
       break;
     case bitc::TYPE_CODE_PPC_FP128: // PPC_FP128
       ResultTy = Type::getPPC_FP128Ty(Context);
-      break;
-    case bitc::TYPE_CODE_DECIMAL128: // 128-bit DFP
-      ResultTy = Type::getDecimal128Ty(Context);
       break;
     case bitc::TYPE_CODE_LABEL:     // LABEL
       ResultTy = Type::getLabelTy(Context);
@@ -2517,6 +2508,15 @@ Error BitcodeReader::parseTypeTableBody() {
       TypeName.clear();
       break;
     }
+    case bitc::TYPE_CODE_DECIMAL32: // 32-bit DFP
+      ResultTy = Type::getDecimal32Ty(Context);
+      break;
+    case bitc::TYPE_CODE_DECIMAL64: // 64-bit DFP
+      ResultTy = Type::getDecimal64Ty(Context);
+      break;
+    case bitc::TYPE_CODE_DECIMAL128: // 128-bit DFP
+      ResultTy = Type::getDecimal128Ty(Context);
+      break;
     case bitc::TYPE_CODE_ARRAY:     // ARRAY: [numelts, eltty]
       if (Record.size() < 2)
         return error("Invalid array type record");

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -972,10 +972,19 @@ void ModuleBitcodeWriter::writeTypeTable() {
     case Type::HalfTyID:      Code = bitc::TYPE_CODE_HALF;      break;
     case Type::BFloatTyID:    Code = bitc::TYPE_CODE_BFLOAT;    break;
     case Type::FloatTyID:     Code = bitc::TYPE_CODE_FLOAT;     break;
+    case Type::Decimal32TyID:
+      Code = bitc::TYPE_CODE_DECIMAL32;
+      break;
     case Type::DoubleTyID:    Code = bitc::TYPE_CODE_DOUBLE;    break;
+    case Type::Decimal64TyID:
+      Code = bitc::TYPE_CODE_DECIMAL64;
+      break;
     case Type::X86_FP80TyID:  Code = bitc::TYPE_CODE_X86_FP80;  break;
     case Type::FP128TyID:     Code = bitc::TYPE_CODE_FP128;     break;
     case Type::PPC_FP128TyID: Code = bitc::TYPE_CODE_PPC_FP128; break;
+    case Type::Decimal128TyID:
+      Code = bitc::TYPE_CODE_DECIMAL128;
+      break;
     case Type::LabelTyID:     Code = bitc::TYPE_CODE_LABEL;     break;
     case Type::MetadataTyID:  Code = bitc::TYPE_CODE_METADATA;  break;
     case Type::X86_MMXTyID:   Code = bitc::TYPE_CODE_X86_MMX;   break;

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -968,19 +968,19 @@ void ModuleBitcodeWriter::writeTypeTable() {
     unsigned Code = 0;
 
     switch (T->getTypeID()) {
-    case Type::VoidTyID:       Code = bitc::TYPE_CODE_VOID;       break;
-    case Type::HalfTyID:       Code = bitc::TYPE_CODE_HALF;       break;
-    case Type::BFloatTyID:     Code = bitc::TYPE_CODE_BFLOAT;     break;
-    case Type::FloatTyID:      Code = bitc::TYPE_CODE_FLOAT;      break;
-    case Type::DoubleTyID:     Code = bitc::TYPE_CODE_DOUBLE;     break;
-    case Type::X86_FP80TyID:   Code = bitc::TYPE_CODE_X86_FP80;   break;
-    case Type::FP128TyID:      Code = bitc::TYPE_CODE_FP128;      break;
-    case Type::PPC_FP128TyID:  Code = bitc::TYPE_CODE_PPC_FP128;  break;
-    case Type::LabelTyID:      Code = bitc::TYPE_CODE_LABEL;      break;
-    case Type::MetadataTyID:   Code = bitc::TYPE_CODE_METADATA;   break;
-    case Type::X86_MMXTyID:    Code = bitc::TYPE_CODE_X86_MMX;    break;
-    case Type::X86_AMXTyID:    Code = bitc::TYPE_CODE_X86_AMX;    break;
-    case Type::TokenTyID:      Code = bitc::TYPE_CODE_TOKEN;      break;
+    case Type::VoidTyID:      Code = bitc::TYPE_CODE_VOID;      break;
+    case Type::HalfTyID:      Code = bitc::TYPE_CODE_HALF;      break;
+    case Type::BFloatTyID:    Code = bitc::TYPE_CODE_BFLOAT;    break;
+    case Type::FloatTyID:     Code = bitc::TYPE_CODE_FLOAT;     break;
+    case Type::DoubleTyID:    Code = bitc::TYPE_CODE_DOUBLE;    break;
+    case Type::X86_FP80TyID:  Code = bitc::TYPE_CODE_X86_FP80;  break;
+    case Type::FP128TyID:     Code = bitc::TYPE_CODE_FP128;     break;
+    case Type::PPC_FP128TyID: Code = bitc::TYPE_CODE_PPC_FP128; break;
+    case Type::LabelTyID:     Code = bitc::TYPE_CODE_LABEL;     break;
+    case Type::MetadataTyID:  Code = bitc::TYPE_CODE_METADATA;  break;
+    case Type::X86_MMXTyID:   Code = bitc::TYPE_CODE_X86_MMX;   break;
+    case Type::X86_AMXTyID:   Code = bitc::TYPE_CODE_X86_AMX;   break;
+    case Type::TokenTyID:     Code = bitc::TYPE_CODE_TOKEN;     break;
     case Type::IntegerTyID:
       // INTEGER: [width]
       Code = bitc::TYPE_CODE_INTEGER;

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -976,6 +976,9 @@ void ModuleBitcodeWriter::writeTypeTable() {
     case Type::X86_FP80TyID:  Code = bitc::TYPE_CODE_X86_FP80;  break;
     case Type::FP128TyID:     Code = bitc::TYPE_CODE_FP128;     break;
     case Type::PPC_FP128TyID: Code = bitc::TYPE_CODE_PPC_FP128; break;
+    case Type::Decimal32TyID: Code = bitc::TYPE_CODE_DECIMAL32; break;
+    case Type::Decimal64TyID: Code = bitc::TYPE_CODE_DECIMAL64; break;
+    case Type::Decimal128TyID: Code = bitc::TYPE_CODE_DECIMAL128; break;
     case Type::LabelTyID:     Code = bitc::TYPE_CODE_LABEL;     break;
     case Type::MetadataTyID:  Code = bitc::TYPE_CODE_METADATA;  break;
     case Type::X86_MMXTyID:   Code = bitc::TYPE_CODE_X86_MMX;   break;
@@ -1068,15 +1071,6 @@ void ModuleBitcodeWriter::writeTypeTable() {
     }
     case Type::TypedPointerTyID:
       llvm_unreachable("Typed pointers cannot be added to IR modules");
-    case Type::Decimal32TyID:
-      Code = bitc::TYPE_CODE_DECIMAL32;
-      break;
-    case Type::Decimal64TyID:
-      Code = bitc::TYPE_CODE_DECIMAL64;
-      break;
-    case Type::Decimal128TyID:
-      Code = bitc::TYPE_CODE_DECIMAL128;
-      break;
     }
 
     // Emit the finished record.

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -968,28 +968,22 @@ void ModuleBitcodeWriter::writeTypeTable() {
     unsigned Code = 0;
 
     switch (T->getTypeID()) {
-    case Type::VoidTyID:      Code = bitc::TYPE_CODE_VOID;      break;
-    case Type::HalfTyID:      Code = bitc::TYPE_CODE_HALF;      break;
-    case Type::BFloatTyID:    Code = bitc::TYPE_CODE_BFLOAT;    break;
-    case Type::FloatTyID:     Code = bitc::TYPE_CODE_FLOAT;     break;
-    case Type::Decimal32TyID:
-      Code = bitc::TYPE_CODE_DECIMAL32;
-      break;
-    case Type::DoubleTyID:    Code = bitc::TYPE_CODE_DOUBLE;    break;
-    case Type::Decimal64TyID:
-      Code = bitc::TYPE_CODE_DECIMAL64;
-      break;
-    case Type::X86_FP80TyID:  Code = bitc::TYPE_CODE_X86_FP80;  break;
-    case Type::FP128TyID:     Code = bitc::TYPE_CODE_FP128;     break;
-    case Type::PPC_FP128TyID: Code = bitc::TYPE_CODE_PPC_FP128; break;
-    case Type::Decimal128TyID:
-      Code = bitc::TYPE_CODE_DECIMAL128;
-      break;
-    case Type::LabelTyID:     Code = bitc::TYPE_CODE_LABEL;     break;
-    case Type::MetadataTyID:  Code = bitc::TYPE_CODE_METADATA;  break;
-    case Type::X86_MMXTyID:   Code = bitc::TYPE_CODE_X86_MMX;   break;
-    case Type::X86_AMXTyID:   Code = bitc::TYPE_CODE_X86_AMX;   break;
-    case Type::TokenTyID:     Code = bitc::TYPE_CODE_TOKEN;     break;
+    case Type::VoidTyID:       Code = bitc::TYPE_CODE_VOID;       break;
+    case Type::HalfTyID:       Code = bitc::TYPE_CODE_HALF;       break;
+    case Type::BFloatTyID:     Code = bitc::TYPE_CODE_BFLOAT;     break;
+    case Type::FloatTyID:      Code = bitc::TYPE_CODE_FLOAT;      break;
+    case Type::Decimal32TyID:  Code = bitc::TYPE_CODE_DECIMAL32;  break;
+    case Type::DoubleTyID:     Code = bitc::TYPE_CODE_DOUBLE;     break;
+    case Type::Decimal64TyID:  Code = bitc::TYPE_CODE_DECIMAL64;  break;
+    case Type::X86_FP80TyID:   Code = bitc::TYPE_CODE_X86_FP80;   break;
+    case Type::FP128TyID:      Code = bitc::TYPE_CODE_FP128;      break;
+    case Type::PPC_FP128TyID:  Code = bitc::TYPE_CODE_PPC_FP128;  break;
+    case Type::Decimal128TyID: Code = bitc::TYPE_CODE_DECIMAL128; break;
+    case Type::LabelTyID:      Code = bitc::TYPE_CODE_LABEL;      break;
+    case Type::MetadataTyID:   Code = bitc::TYPE_CODE_METADATA;   break;
+    case Type::X86_MMXTyID:    Code = bitc::TYPE_CODE_X86_MMX;    break;
+    case Type::X86_AMXTyID:    Code = bitc::TYPE_CODE_X86_AMX;    break;
+    case Type::TokenTyID:      Code = bitc::TYPE_CODE_TOKEN;      break;
     case Type::IntegerTyID:
       // INTEGER: [width]
       Code = bitc::TYPE_CODE_INTEGER;

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -972,13 +972,10 @@ void ModuleBitcodeWriter::writeTypeTable() {
     case Type::HalfTyID:       Code = bitc::TYPE_CODE_HALF;       break;
     case Type::BFloatTyID:     Code = bitc::TYPE_CODE_BFLOAT;     break;
     case Type::FloatTyID:      Code = bitc::TYPE_CODE_FLOAT;      break;
-    case Type::Decimal32TyID:  Code = bitc::TYPE_CODE_DECIMAL32;  break;
     case Type::DoubleTyID:     Code = bitc::TYPE_CODE_DOUBLE;     break;
-    case Type::Decimal64TyID:  Code = bitc::TYPE_CODE_DECIMAL64;  break;
     case Type::X86_FP80TyID:   Code = bitc::TYPE_CODE_X86_FP80;   break;
     case Type::FP128TyID:      Code = bitc::TYPE_CODE_FP128;      break;
     case Type::PPC_FP128TyID:  Code = bitc::TYPE_CODE_PPC_FP128;  break;
-    case Type::Decimal128TyID: Code = bitc::TYPE_CODE_DECIMAL128; break;
     case Type::LabelTyID:      Code = bitc::TYPE_CODE_LABEL;      break;
     case Type::MetadataTyID:   Code = bitc::TYPE_CODE_METADATA;   break;
     case Type::X86_MMXTyID:    Code = bitc::TYPE_CODE_X86_MMX;    break;
@@ -1071,6 +1068,15 @@ void ModuleBitcodeWriter::writeTypeTable() {
     }
     case Type::TypedPointerTyID:
       llvm_unreachable("Typed pointers cannot be added to IR modules");
+    case Type::Decimal32TyID:
+      Code = bitc::TYPE_CODE_DECIMAL32;
+      break;
+    case Type::Decimal64TyID:
+      Code = bitc::TYPE_CODE_DECIMAL64;
+      break;
+    case Type::Decimal128TyID:
+      Code = bitc::TYPE_CODE_DECIMAL128;
+      break;
     }
 
     // Emit the finished record.

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -549,10 +549,19 @@ void TypePrinting::print(Type *Ty, raw_ostream &OS) {
   case Type::HalfTyID:      OS << "half"; return;
   case Type::BFloatTyID:    OS << "bfloat"; return;
   case Type::FloatTyID:     OS << "float"; return;
+  case Type::Decimal32TyID:
+    OS << "decimal32";
+    return;
   case Type::DoubleTyID:    OS << "double"; return;
+  case Type::Decimal64TyID:
+    OS << "decimal64";
+    return;
   case Type::X86_FP80TyID:  OS << "x86_fp80"; return;
   case Type::FP128TyID:     OS << "fp128"; return;
   case Type::PPC_FP128TyID: OS << "ppc_fp128"; return;
+  case Type::Decimal128TyID:
+    OS << "decimal128";
+    return;
   case Type::LabelTyID:     OS << "label"; return;
   case Type::MetadataTyID:  OS << "metadata"; return;
   case Type::X86_MMXTyID:   OS << "x86_mmx"; return;

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -545,25 +545,25 @@ void TypePrinting::incorporateTypes() {
 /// names or up references to shorten the type name where possible.
 void TypePrinting::print(Type *Ty, raw_ostream &OS) {
   switch (Ty->getTypeID()) {
-  case Type::VoidTyID:       OS << "void"; return;
-  case Type::HalfTyID:       OS << "half"; return;
-  case Type::BFloatTyID:     OS << "bfloat"; return;
-  case Type::FloatTyID:      OS << "float"; return;
-  case Type::Decimal32TyID:  OS << "decimal32"; return;
-  case Type::DoubleTyID:     OS << "double"; return;
-  case Type::Decimal64TyID:  OS << "decimal64"; return;
-  case Type::X86_FP80TyID:   OS << "x86_fp80"; return;
-  case Type::FP128TyID:      OS << "fp128"; return;
-  case Type::PPC_FP128TyID:  OS << "ppc_fp128"; return;
-  case Type::Decimal128TyID: OS << "decimal128"; return;
-  case Type::LabelTyID:      OS << "label"; return;
-  case Type::MetadataTyID:   OS << "metadata"; return;
-  case Type::X86_MMXTyID:    OS << "x86_mmx"; return;
-  case Type::X86_AMXTyID:    OS << "x86_amx"; return;
-  case Type::TokenTyID:      OS << "token"; return;
+  case Type::VoidTyID:      OS << "void"; return;
+  case Type::HalfTyID:      OS << "half"; return;
+  case Type::BFloatTyID:    OS << "bfloat"; return;
+  case Type::FloatTyID:     OS << "float"; return;
+  case Type::DoubleTyID:    OS << "double"; return;
+  case Type::X86_FP80TyID:  OS << "x86_fp80"; return;
+  case Type::FP128TyID:     OS << "fp128"; return;
+  case Type::PPC_FP128TyID: OS << "ppc_fp128"; return;
+  case Type::LabelTyID:     OS << "label"; return;
+  case Type::MetadataTyID:  OS << "metadata"; return;
+  case Type::X86_MMXTyID:   OS << "x86_mmx"; return;
+  case Type::X86_AMXTyID:   OS << "x86_amx"; return;
+  case Type::TokenTyID:     OS << "token"; return;
   case Type::IntegerTyID:
     OS << 'i' << cast<IntegerType>(Ty)->getBitWidth();
     return;
+  case Type::Decimal32TyID:  OS << "decimal32"; return;
+  case Type::Decimal64TyID:  OS << "decimal64"; return;
+  case Type::Decimal128TyID: OS << "decimal128"; return;
 
   case Type::FunctionTyID: {
     FunctionType *FTy = cast<FunctionType>(Ty);

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -545,28 +545,22 @@ void TypePrinting::incorporateTypes() {
 /// names or up references to shorten the type name where possible.
 void TypePrinting::print(Type *Ty, raw_ostream &OS) {
   switch (Ty->getTypeID()) {
-  case Type::VoidTyID:      OS << "void"; return;
-  case Type::HalfTyID:      OS << "half"; return;
-  case Type::BFloatTyID:    OS << "bfloat"; return;
-  case Type::FloatTyID:     OS << "float"; return;
-  case Type::Decimal32TyID:
-    OS << "decimal32";
-    return;
-  case Type::DoubleTyID:    OS << "double"; return;
-  case Type::Decimal64TyID:
-    OS << "decimal64";
-    return;
-  case Type::X86_FP80TyID:  OS << "x86_fp80"; return;
-  case Type::FP128TyID:     OS << "fp128"; return;
-  case Type::PPC_FP128TyID: OS << "ppc_fp128"; return;
-  case Type::Decimal128TyID:
-    OS << "decimal128";
-    return;
-  case Type::LabelTyID:     OS << "label"; return;
-  case Type::MetadataTyID:  OS << "metadata"; return;
-  case Type::X86_MMXTyID:   OS << "x86_mmx"; return;
-  case Type::X86_AMXTyID:   OS << "x86_amx"; return;
-  case Type::TokenTyID:     OS << "token"; return;
+  case Type::VoidTyID:       OS << "void"; return;
+  case Type::HalfTyID:       OS << "half"; return;
+  case Type::BFloatTyID:     OS << "bfloat"; return;
+  case Type::FloatTyID:      OS << "float"; return;
+  case Type::Decimal32TyID:  OS << "decimal32"; return;
+  case Type::DoubleTyID:     OS << "double"; return;
+  case Type::Decimal64TyID:  OS << "decimal64"; return;
+  case Type::X86_FP80TyID:   OS << "x86_fp80"; return;
+  case Type::FP128TyID:      OS << "fp128"; return;
+  case Type::PPC_FP128TyID:  OS << "ppc_fp128"; return;
+  case Type::Decimal128TyID: OS << "decimal128"; return;
+  case Type::LabelTyID:      OS << "label"; return;
+  case Type::MetadataTyID:   OS << "metadata"; return;
+  case Type::X86_MMXTyID:    OS << "x86_mmx"; return;
+  case Type::X86_AMXTyID:    OS << "x86_amx"; return;
+  case Type::TokenTyID:      OS << "token"; return;
   case Type::IntegerTyID:
     OS << 'i' << cast<IntegerType>(Ty)->getBitWidth();
     return;

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -555,14 +555,20 @@ LLVMTypeKind LLVMGetTypeKind(LLVMTypeRef Ty) {
     return LLVMBFloatTypeKind;
   case Type::FloatTyID:
     return LLVMFloatTypeKind;
+  case Type::Decimal32TyID:
+    return LLVMDecimal32TypeKind;
   case Type::DoubleTyID:
     return LLVMDoubleTypeKind;
+  case Type::Decimal64TyID:
+    return LLVMDecimal64TypeKind;
   case Type::X86_FP80TyID:
     return LLVMX86_FP80TypeKind;
   case Type::FP128TyID:
     return LLVMFP128TypeKind;
   case Type::PPC_FP128TyID:
     return LLVMPPC_FP128TypeKind;
+  case Type::Decimal128TyID:
+    return LLVMDecimal128TypeKind;
   case Type::LabelTyID:
     return LLVMLabelTypeKind;
   case Type::MetadataTyID:

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -563,6 +563,12 @@ LLVMTypeKind LLVMGetTypeKind(LLVMTypeRef Ty) {
     return LLVMFP128TypeKind;
   case Type::PPC_FP128TyID:
     return LLVMPPC_FP128TypeKind;
+  case Type::Decimal32TyID:
+    return LLVMDecimal32TypeKind;
+  case Type::Decimal64TyID:
+    return LLVMDecimal64TypeKind;
+  case Type::Decimal128TyID:
+    return LLVMDecimal128TypeKind;
   case Type::LabelTyID:
     return LLVMLabelTypeKind;
   case Type::MetadataTyID:
@@ -591,12 +597,6 @@ LLVMTypeKind LLVMGetTypeKind(LLVMTypeRef Ty) {
     return LLVMTargetExtTypeKind;
   case Type::TypedPointerTyID:
     llvm_unreachable("Typed pointers are unsupported via the C API");
-  case Type::Decimal32TyID:
-    return LLVMDecimal32TypeKind;
-  case Type::Decimal64TyID:
-    return LLVMDecimal64TypeKind;
-  case Type::Decimal128TyID:
-    return LLVMDecimal128TypeKind;
   }
   llvm_unreachable("Unhandled TypeID.");
 }

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -555,20 +555,14 @@ LLVMTypeKind LLVMGetTypeKind(LLVMTypeRef Ty) {
     return LLVMBFloatTypeKind;
   case Type::FloatTyID:
     return LLVMFloatTypeKind;
-  case Type::Decimal32TyID:
-    return LLVMDecimal32TypeKind;
   case Type::DoubleTyID:
     return LLVMDoubleTypeKind;
-  case Type::Decimal64TyID:
-    return LLVMDecimal64TypeKind;
   case Type::X86_FP80TyID:
     return LLVMX86_FP80TypeKind;
   case Type::FP128TyID:
     return LLVMFP128TypeKind;
   case Type::PPC_FP128TyID:
     return LLVMPPC_FP128TypeKind;
-  case Type::Decimal128TyID:
-    return LLVMDecimal128TypeKind;
   case Type::LabelTyID:
     return LLVMLabelTypeKind;
   case Type::MetadataTyID:
@@ -597,6 +591,12 @@ LLVMTypeKind LLVMGetTypeKind(LLVMTypeRef Ty) {
     return LLVMTargetExtTypeKind;
   case Type::TypedPointerTyID:
     llvm_unreachable("Typed pointers are unsupported via the C API");
+  case Type::Decimal32TyID:
+    return LLVMDecimal32TypeKind;
+  case Type::Decimal64TyID:
+    return LLVMDecimal64TypeKind;
+  case Type::Decimal128TyID:
+    return LLVMDecimal128TypeKind;
   }
   llvm_unreachable("Unhandled TypeID.");
 }

--- a/llvm/lib/IR/LLVMContextImpl.cpp
+++ b/llvm/lib/IR/LLVMContextImpl.cpp
@@ -37,10 +37,12 @@ LLVMContextImpl::LLVMContextImpl(LLVMContext &C)
     : DiagHandler(std::make_unique<DiagnosticHandler>()),
       VoidTy(C, Type::VoidTyID), LabelTy(C, Type::LabelTyID),
       HalfTy(C, Type::HalfTyID), BFloatTy(C, Type::BFloatTyID),
-      FloatTy(C, Type::FloatTyID), DoubleTy(C, Type::DoubleTyID),
+      FloatTy(C, Type::FloatTyID), Decimal32Ty(C, Type::Decimal32TyID),
+      DoubleTy(C, Type::DoubleTyID), Decimal64Ty(C, Type::Decimal64TyID),
       MetadataTy(C, Type::MetadataTyID), TokenTy(C, Type::TokenTyID),
       X86_FP80Ty(C, Type::X86_FP80TyID), FP128Ty(C, Type::FP128TyID),
-      PPC_FP128Ty(C, Type::PPC_FP128TyID), X86_MMXTy(C, Type::X86_MMXTyID),
+      PPC_FP128Ty(C, Type::PPC_FP128TyID),
+      Decimal128Ty(C, Type::Decimal128TyID), X86_MMXTy(C, Type::X86_MMXTyID),
       X86_AMXTy(C, Type::X86_AMXTyID), Int1Ty(C, 1), Int8Ty(C, 8),
       Int16Ty(C, 16), Int32Ty(C, 32), Int64Ty(C, 64), Int128Ty(C, 128) {}
 

--- a/llvm/lib/IR/LLVMContextImpl.cpp
+++ b/llvm/lib/IR/LLVMContextImpl.cpp
@@ -37,14 +37,14 @@ LLVMContextImpl::LLVMContextImpl(LLVMContext &C)
     : DiagHandler(std::make_unique<DiagnosticHandler>()),
       VoidTy(C, Type::VoidTyID), LabelTy(C, Type::LabelTyID),
       HalfTy(C, Type::HalfTyID), BFloatTy(C, Type::BFloatTyID),
-      FloatTy(C, Type::FloatTyID), Decimal32Ty(C, Type::Decimal32TyID),
-      DoubleTy(C, Type::DoubleTyID), Decimal64Ty(C, Type::Decimal64TyID),
+      FloatTy(C, Type::FloatTyID), DoubleTy(C, Type::DoubleTyID),
       MetadataTy(C, Type::MetadataTyID), TokenTy(C, Type::TokenTyID),
       X86_FP80Ty(C, Type::X86_FP80TyID), FP128Ty(C, Type::FP128TyID),
-      PPC_FP128Ty(C, Type::PPC_FP128TyID),
-      Decimal128Ty(C, Type::Decimal128TyID), X86_MMXTy(C, Type::X86_MMXTyID),
+      PPC_FP128Ty(C, Type::PPC_FP128TyID), X86_MMXTy(C, Type::X86_MMXTyID),
       X86_AMXTy(C, Type::X86_AMXTyID), Int1Ty(C, 1), Int8Ty(C, 8),
-      Int16Ty(C, 16), Int32Ty(C, 32), Int64Ty(C, 64), Int128Ty(C, 128) {}
+      Int16Ty(C, 16), Int32Ty(C, 32), Int64Ty(C, 64), Int128Ty(C, 128),
+      Decimal32Ty(C, Type::Decimal32TyID), Decimal64Ty(C, Type::Decimal64TyID),
+      Decimal128Ty(C, Type::Decimal128TyID) {}
 
 LLVMContextImpl::~LLVMContextImpl() {
   // NOTE: We need to delete the contents of OwnedModules, but Module's dtor

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -1520,9 +1520,10 @@ public:
   ConstantInt *TheFalseVal = nullptr;
 
   // Basic type instances.
-  Type VoidTy, LabelTy, HalfTy, BFloatTy, FloatTy, DoubleTy, MetadataTy,
+  Type VoidTy, LabelTy, HalfTy, BFloatTy, FloatTy, Decimal32Ty, DoubleTy,
+      Decimal64Ty, MetadataTy,
       TokenTy;
-  Type X86_FP80Ty, FP128Ty, PPC_FP128Ty, X86_MMXTy, X86_AMXTy;
+  Type X86_FP80Ty, FP128Ty, PPC_FP128Ty, Decimal128Ty, X86_MMXTy, X86_AMXTy;
   IntegerType Int1Ty, Int8Ty, Int16Ty, Int32Ty, Int64Ty, Int128Ty;
 
   std::unique_ptr<ConstantTokenNone> TheNoneToken;

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -1520,10 +1520,11 @@ public:
   ConstantInt *TheFalseVal = nullptr;
 
   // Basic type instances.
-  Type VoidTy, LabelTy, HalfTy, BFloatTy, FloatTy, Decimal32Ty, DoubleTy;
-  Type Decimal64Ty, MetadataTy, TokenTy;
-  Type X86_FP80Ty, FP128Ty, PPC_FP128Ty, Decimal128Ty, X86_MMXTy, X86_AMXTy;
+  Type VoidTy, LabelTy, HalfTy, BFloatTy, FloatTy, DoubleTy, MetadataTy,
+      TokenTy;
+  Type X86_FP80Ty, FP128Ty, PPC_FP128Ty, X86_MMXTy, X86_AMXTy;
   IntegerType Int1Ty, Int8Ty, Int16Ty, Int32Ty, Int64Ty, Int128Ty;
+  Type Decimal32Ty, Decimal64Ty, Decimal128Ty;
 
   std::unique_ptr<ConstantTokenNone> TheNoneToken;
 

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -1520,9 +1520,8 @@ public:
   ConstantInt *TheFalseVal = nullptr;
 
   // Basic type instances.
-  Type VoidTy, LabelTy, HalfTy, BFloatTy, FloatTy, Decimal32Ty, DoubleTy,
-      Decimal64Ty, MetadataTy,
-      TokenTy;
+  Type VoidTy, LabelTy, HalfTy, BFloatTy, FloatTy, Decimal32Ty, DoubleTy;
+  Type Decimal64Ty, MetadataTy, TokenTy;
   Type X86_FP80Ty, FP128Ty, PPC_FP128Ty, Decimal128Ty, X86_MMXTy, X86_AMXTy;
   IntegerType Int1Ty, Int8Ty, Int16Ty, Int32Ty, Int64Ty, Int128Ty;
 

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -39,10 +39,16 @@ Type *Type::getPrimitiveType(LLVMContext &C, TypeID IDNumber) {
   case HalfTyID      : return getHalfTy(C);
   case BFloatTyID    : return getBFloatTy(C);
   case FloatTyID     : return getFloatTy(C);
+  case Decimal32TyID:
+    return getDecimal32Ty(C);
   case DoubleTyID    : return getDoubleTy(C);
+  case Decimal64TyID:
+    return getDecimal64Ty(C);
   case X86_FP80TyID  : return getX86_FP80Ty(C);
   case FP128TyID     : return getFP128Ty(C);
   case PPC_FP128TyID : return getPPC_FP128Ty(C);
+  case Decimal128TyID:
+    return getDecimal128Ty(C);
   case LabelTyID     : return getLabelTy(C);
   case MetadataTyID  : return getMetadataTy(C);
   case X86_MMXTyID   : return getX86_MMXTy(C);
@@ -175,10 +181,13 @@ TypeSize Type::getPrimitiveSizeInBits() const {
   case Type::HalfTyID: return TypeSize::Fixed(16);
   case Type::BFloatTyID: return TypeSize::Fixed(16);
   case Type::FloatTyID: return TypeSize::Fixed(32);
+  case Decimal32TyID: return TypeSize::Fixed(32);
   case Type::DoubleTyID: return TypeSize::Fixed(64);
+  case Decimal64TyID: return TypeSize::Fixed(64);
   case Type::X86_FP80TyID: return TypeSize::Fixed(80);
   case Type::FP128TyID: return TypeSize::Fixed(128);
   case Type::PPC_FP128TyID: return TypeSize::Fixed(128);
+  case Decimal128TyID: return TypeSize::Fixed(128);
   case Type::X86_MMXTyID: return TypeSize::Fixed(64);
   case Type::X86_AMXTyID: return TypeSize::Fixed(8192);
   case Type::IntegerTyID:
@@ -207,9 +216,15 @@ int Type::getFPMantissaWidth() const {
   if (getTypeID() == HalfTyID) return 11;
   if (getTypeID() == BFloatTyID) return 8;
   if (getTypeID() == FloatTyID) return 24;
+  // TODO - Does this depend on the encoding format used (BID or DPD)?
+  if (getTypeID() == Decimal32TyID) return 20;
   if (getTypeID() == DoubleTyID) return 53;
+  // TODO - Does this depend on the encoding format used (BID or DPD)?
+  if (getTypeID() == Decimal64TyID) return 50;
   if (getTypeID() == X86_FP80TyID) return 64;
   if (getTypeID() == FP128TyID) return 113;
+  // TODO - Does this depend on the encoding format used (BID or DPD)?
+  if (getTypeID() == Decimal128TyID) return 110;
   assert(getTypeID() == PPC_FP128TyID && "unknown fp type");
   return -1;
 }
@@ -236,12 +251,15 @@ Type *Type::getLabelTy(LLVMContext &C) { return &C.pImpl->LabelTy; }
 Type *Type::getHalfTy(LLVMContext &C) { return &C.pImpl->HalfTy; }
 Type *Type::getBFloatTy(LLVMContext &C) { return &C.pImpl->BFloatTy; }
 Type *Type::getFloatTy(LLVMContext &C) { return &C.pImpl->FloatTy; }
+Type *Type::getDecimal32Ty(LLVMContext &C) { return &C.pImpl->Decimal32Ty; }
 Type *Type::getDoubleTy(LLVMContext &C) { return &C.pImpl->DoubleTy; }
+Type *Type::getDecimal64Ty(LLVMContext &C) { return &C.pImpl->Decimal64Ty; }
 Type *Type::getMetadataTy(LLVMContext &C) { return &C.pImpl->MetadataTy; }
 Type *Type::getTokenTy(LLVMContext &C) { return &C.pImpl->TokenTy; }
 Type *Type::getX86_FP80Ty(LLVMContext &C) { return &C.pImpl->X86_FP80Ty; }
 Type *Type::getFP128Ty(LLVMContext &C) { return &C.pImpl->FP128Ty; }
 Type *Type::getPPC_FP128Ty(LLVMContext &C) { return &C.pImpl->PPC_FP128Ty; }
+Type *Type::getDecimal128Ty(LLVMContext &C) { return &C.pImpl->Decimal128Ty; }
 Type *Type::getX86_MMXTy(LLVMContext &C) { return &C.pImpl->X86_MMXTy; }
 Type *Type::getX86_AMXTy(LLVMContext &C) { return &C.pImpl->X86_AMXTy; }
 

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -48,8 +48,8 @@ Type *Type::getPrimitiveType(LLVMContext &C, TypeID IDNumber) {
   case X86_MMXTyID   : return getX86_MMXTy(C);
   case X86_AMXTyID   : return getX86_AMXTy(C);
   case TokenTyID     : return getTokenTy(C);
-  case Decimal32TyID:  return getDecimal32Ty(C);
-  case Decimal64TyID:  return getDecimal64Ty(C);
+  case Decimal32TyID :  return getDecimal32Ty(C);
+  case Decimal64TyID :  return getDecimal64Ty(C);
   case Decimal128TyID: return getDecimal128Ty(C);
   default:
     return nullptr;

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -224,7 +224,8 @@ int Type::getDFPPrecisionInDigits() const {
   if (auto *VTy = dyn_cast<VectorType>(this))
     return VTy->getElementType()->getDFPPrecisionInDigits();
   assert(isDecimalFloatingPointTy() && "Not a decimal floating point type!");
-  // Precision values following the table in section X.2.1 of WG14 N2601.
+  // Precision values per the "Decimal interchange format parameters" table of
+  /// C23 annex H.2.1, "Interchange floating types".
   if (getTypeID() == Decimal32TyID) return 7;
   if (getTypeID() == Decimal64TyID) return 16;
   if (getTypeID() == Decimal128TyID) return 34;

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -39,18 +39,18 @@ Type *Type::getPrimitiveType(LLVMContext &C, TypeID IDNumber) {
   case HalfTyID      : return getHalfTy(C);
   case BFloatTyID    : return getBFloatTy(C);
   case FloatTyID     : return getFloatTy(C);
-  case Decimal32TyID:  return getDecimal32Ty(C);
   case DoubleTyID    : return getDoubleTy(C);
-  case Decimal64TyID:  return getDecimal64Ty(C);
   case X86_FP80TyID  : return getX86_FP80Ty(C);
   case FP128TyID     : return getFP128Ty(C);
   case PPC_FP128TyID : return getPPC_FP128Ty(C);
-  case Decimal128TyID: return getDecimal128Ty(C);
   case LabelTyID     : return getLabelTy(C);
   case MetadataTyID  : return getMetadataTy(C);
   case X86_MMXTyID   : return getX86_MMXTy(C);
   case X86_AMXTyID   : return getX86_AMXTy(C);
   case TokenTyID     : return getTokenTy(C);
+  case Decimal32TyID:  return getDecimal32Ty(C);
+  case Decimal64TyID:  return getDecimal64Ty(C);
+  case Decimal128TyID: return getDecimal128Ty(C);
   default:
     return nullptr;
   }
@@ -178,13 +178,10 @@ TypeSize Type::getPrimitiveSizeInBits() const {
   case Type::HalfTyID: return TypeSize::Fixed(16);
   case Type::BFloatTyID: return TypeSize::Fixed(16);
   case Type::FloatTyID: return TypeSize::Fixed(32);
-  case Decimal32TyID: return TypeSize::Fixed(32);
   case Type::DoubleTyID: return TypeSize::Fixed(64);
-  case Decimal64TyID: return TypeSize::Fixed(64);
   case Type::X86_FP80TyID: return TypeSize::Fixed(80);
   case Type::FP128TyID: return TypeSize::Fixed(128);
   case Type::PPC_FP128TyID: return TypeSize::Fixed(128);
-  case Decimal128TyID: return TypeSize::Fixed(128);
   case Type::X86_MMXTyID: return TypeSize::Fixed(64);
   case Type::X86_AMXTyID: return TypeSize::Fixed(8192);
   case Type::IntegerTyID:
@@ -197,6 +194,9 @@ TypeSize Type::getPrimitiveSizeInBits() const {
     assert(!ETS.isScalable() && "Vector type should have fixed-width elements");
     return {ETS.getFixedValue() * EC.getKnownMinValue(), EC.isScalable()};
   }
+  case Decimal32TyID: return TypeSize::Fixed(32);
+  case Decimal64TyID: return TypeSize::Fixed(64);
+  case Decimal128TyID: return TypeSize::Fixed(128);
   default: return TypeSize::Fixed(0);
   }
 }
@@ -251,17 +251,18 @@ Type *Type::getLabelTy(LLVMContext &C) { return &C.pImpl->LabelTy; }
 Type *Type::getHalfTy(LLVMContext &C) { return &C.pImpl->HalfTy; }
 Type *Type::getBFloatTy(LLVMContext &C) { return &C.pImpl->BFloatTy; }
 Type *Type::getFloatTy(LLVMContext &C) { return &C.pImpl->FloatTy; }
-Type *Type::getDecimal32Ty(LLVMContext &C) { return &C.pImpl->Decimal32Ty; }
 Type *Type::getDoubleTy(LLVMContext &C) { return &C.pImpl->DoubleTy; }
-Type *Type::getDecimal64Ty(LLVMContext &C) { return &C.pImpl->Decimal64Ty; }
 Type *Type::getMetadataTy(LLVMContext &C) { return &C.pImpl->MetadataTy; }
 Type *Type::getTokenTy(LLVMContext &C) { return &C.pImpl->TokenTy; }
 Type *Type::getX86_FP80Ty(LLVMContext &C) { return &C.pImpl->X86_FP80Ty; }
 Type *Type::getFP128Ty(LLVMContext &C) { return &C.pImpl->FP128Ty; }
 Type *Type::getPPC_FP128Ty(LLVMContext &C) { return &C.pImpl->PPC_FP128Ty; }
-Type *Type::getDecimal128Ty(LLVMContext &C) { return &C.pImpl->Decimal128Ty; }
 Type *Type::getX86_MMXTy(LLVMContext &C) { return &C.pImpl->X86_MMXTy; }
 Type *Type::getX86_AMXTy(LLVMContext &C) { return &C.pImpl->X86_AMXTy; }
+
+Type *Type::getDecimal32Ty(LLVMContext &C) { return &C.pImpl->Decimal32Ty; }
+Type *Type::getDecimal64Ty(LLVMContext &C) { return &C.pImpl->Decimal64Ty; }
+Type *Type::getDecimal128Ty(LLVMContext &C) { return &C.pImpl->Decimal128Ty; }
 
 IntegerType *Type::getInt1Ty(LLVMContext &C) { return &C.pImpl->Int1Ty; }
 IntegerType *Type::getInt8Ty(LLVMContext &C) { return &C.pImpl->Int8Ty; }

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -216,13 +216,17 @@ int Type::getFPMantissaWidth() const {
   if (getTypeID() == DoubleTyID) return 53;
   if (getTypeID() == X86_FP80TyID) return 64;
   if (getTypeID() == FP128TyID) return 113;
-  // See comment in the declaration of Type::getFPMantissaWidth();
-  // it returns -1 if the FP type does not have a stable mantissa.
-  if (getTypeID() == Decimal32TyID) return -1;
-  if (getTypeID() == Decimal64TyID) return -1;
-  if (getTypeID() == FP128TyID) return -1;
-  if (getTypeID() == PPC_FP128TyID) return -1;
-  assert("unknown fp type");
+  assert(getTypeID() == PPC_FP128TyID && "unknown fp type");
+  return -1;
+}
+
+int Type::getDFPMantissaWidth() const {
+  if (auto *VTy = dyn_cast<VectorType>(this))
+    return VTy->getElementType()->getDFPMantissaWidth();
+  assert(isDecimalFloatingPointTy() && "Not a decimal floating point type!");
+  // For both BID and DPD the width of the mantissa varies and is dependent
+  // on the combination fields.
+  return -1;
 }
 
 bool Type::isSizedDerivedType(SmallPtrSetImpl<Type*> *Visited) const {

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -39,16 +39,13 @@ Type *Type::getPrimitiveType(LLVMContext &C, TypeID IDNumber) {
   case HalfTyID      : return getHalfTy(C);
   case BFloatTyID    : return getBFloatTy(C);
   case FloatTyID     : return getFloatTy(C);
-  case Decimal32TyID:
-    return getDecimal32Ty(C);
+  case Decimal32TyID:  return getDecimal32Ty(C);
   case DoubleTyID    : return getDoubleTy(C);
-  case Decimal64TyID:
-    return getDecimal64Ty(C);
+  case Decimal64TyID:  return getDecimal64Ty(C);
   case X86_FP80TyID  : return getX86_FP80Ty(C);
   case FP128TyID     : return getFP128Ty(C);
   case PPC_FP128TyID : return getPPC_FP128Ty(C);
-  case Decimal128TyID:
-    return getDecimal128Ty(C);
+  case Decimal128TyID: return getDecimal128Ty(C);
   case LabelTyID     : return getLabelTy(C);
   case MetadataTyID  : return getMetadataTy(C);
   case X86_MMXTyID   : return getX86_MMXTy(C);
@@ -216,16 +213,12 @@ int Type::getFPMantissaWidth() const {
   if (getTypeID() == HalfTyID) return 11;
   if (getTypeID() == BFloatTyID) return 8;
   if (getTypeID() == FloatTyID) return 24;
-  // TODO - Does this depend on the encoding format used (BID or DPD)?
-  if (getTypeID() == Decimal32TyID) return 20;
   if (getTypeID() == DoubleTyID) return 53;
-  // TODO - Does this depend on the encoding format used (BID or DPD)?
-  if (getTypeID() == Decimal64TyID) return 50;
   if (getTypeID() == X86_FP80TyID) return 64;
   if (getTypeID() == FP128TyID) return 113;
-  // TODO - Does this depend on the encoding format used (BID or DPD)?
-  if (getTypeID() == Decimal128TyID) return 110;
-  assert(getTypeID() == PPC_FP128TyID && "unknown fp type");
+  assert((getTypeID() == PPC_FP128TyID || getTypeID() == Decimal32TyID ||
+          getTypeID() == Decimal64TyID || getTypeID() == FP128TyID) &&
+         "unknown fp type");
   return -1;
 }
 

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -220,12 +220,15 @@ int Type::getFPMantissaWidth() const {
   return -1;
 }
 
-int Type::getDFPMantissaWidth() const {
+int Type::getDFPPrecisionInDigits() const {
   if (auto *VTy = dyn_cast<VectorType>(this))
-    return VTy->getElementType()->getDFPMantissaWidth();
+    return VTy->getElementType()->getDFPPrecisionInDigits();
   assert(isDecimalFloatingPointTy() && "Not a decimal floating point type!");
-  // For both BID and DPD the width of the mantissa varies and is dependent
-  // on the combination fields.
+  // Precision values following the table in section X.2.1 of WG14 N2601.
+  if (getTypeID() == Decimal32TyID) return 7;
+  if (getTypeID() == Decimal64TyID) return 16;
+  if (getTypeID() == Decimal128TyID) return 34;
+  assert("unknown decimal floating point type");
   return -1;
 }
 

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -216,10 +216,13 @@ int Type::getFPMantissaWidth() const {
   if (getTypeID() == DoubleTyID) return 53;
   if (getTypeID() == X86_FP80TyID) return 64;
   if (getTypeID() == FP128TyID) return 113;
-  assert((getTypeID() == PPC_FP128TyID || getTypeID() == Decimal32TyID ||
-          getTypeID() == Decimal64TyID || getTypeID() == FP128TyID) &&
-         "unknown fp type");
-  return -1;
+  // See comment in the declaration of Type::getFPMantissaWidth();
+  // it returns -1 if the FP type does not have a stable mantissa.
+  if (getTypeID() == Decimal32TyID) return -1;
+  if (getTypeID() == Decimal64TyID) return -1;
+  if (getTypeID() == FP128TyID) return -1;
+  if (getTypeID() == PPC_FP128TyID) return -1;
+  assert("unknown fp type");
 }
 
 bool Type::isSizedDerivedType(SmallPtrSetImpl<Type*> *Visited) const {

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -182,6 +182,9 @@ TypeSize Type::getPrimitiveSizeInBits() const {
   case Type::X86_FP80TyID: return TypeSize::Fixed(80);
   case Type::FP128TyID: return TypeSize::Fixed(128);
   case Type::PPC_FP128TyID: return TypeSize::Fixed(128);
+  case Decimal32TyID: return TypeSize::Fixed(32);
+  case Decimal64TyID: return TypeSize::Fixed(64);
+  case Decimal128TyID: return TypeSize::Fixed(128);
   case Type::X86_MMXTyID: return TypeSize::Fixed(64);
   case Type::X86_AMXTyID: return TypeSize::Fixed(8192);
   case Type::IntegerTyID:
@@ -194,9 +197,6 @@ TypeSize Type::getPrimitiveSizeInBits() const {
     assert(!ETS.isScalable() && "Vector type should have fixed-width elements");
     return {ETS.getFixedValue() * EC.getKnownMinValue(), EC.isScalable()};
   }
-  case Decimal32TyID: return TypeSize::Fixed(32);
-  case Decimal64TyID: return TypeSize::Fixed(64);
-  case Decimal128TyID: return TypeSize::Fixed(128);
   default: return TypeSize::Fixed(0);
   }
 }
@@ -228,8 +228,7 @@ int Type::getDFPPrecisionInDigits() const {
   if (getTypeID() == Decimal32TyID) return 7;
   if (getTypeID() == Decimal64TyID) return 16;
   if (getTypeID() == Decimal128TyID) return 34;
-  assert("unknown decimal floating point type");
-  return -1;
+  report_fatal_error("unknown decimal floating point type");
 }
 
 bool Type::isSizedDerivedType(SmallPtrSetImpl<Type*> *Visited) const {

--- a/llvm/test/Assembler/dfp.ll
+++ b/llvm/test/Assembler/dfp.ll
@@ -1,0 +1,16 @@
+; RUN: llvm-as < %s | llvm-dis | FileCheck %s --check-prefix=ASSEM-DISASS
+
+define decimal32 @check_decimal32(decimal32 %A) {
+; ASSEM-DISASS: ret decimal32 %A
+    ret decimal32 %A
+}
+
+define decimal64 @check_decimal64(decimal64 %A) {
+; ASSEM-DISASS: ret decimal64 %A
+    ret decimal64 %A
+}
+
+define decimal128 @check_decimal128(decimal128 %A) {
+; ASSEM-DISASS: ret decimal128 %A
+  ret decimal128 %A
+}


### PR DESCRIPTION
Add decimal32, decimal64 and decimal128 IR types.
Still to be done:
APFloat
Constant Folding

Most of the comments were in this (now)closed PR thread. https://github.com/llvm/llvm-project/pull/69718