### PR TITLE
[DFP] Initial changes to supprt DFP under APFloat and parse declarations

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -1115,6 +1115,9 @@ public:
   CanQualType HalfTy; // [OpenCL 6.1.1.1], ARM NEON
   CanQualType BFloat16Ty;
   CanQualType Float16Ty; // C11 extension ISO/IEC TS 18661-3
+  // ISO/IEC TS 18661-2:2015 c23 conditionally supported
+  CanQualType DecimalFloat32Ty, DecimalFloat64Ty, DecimalFloat128Ty;
+  CanQualType DecimalFloatDPD32Ty, DecimalFloatDPD64Ty, DecimalFloatDPD128Ty;
   CanQualType VoidPtrTy, NullPtrTy;
   CanQualType DependentTy, OverloadTy, BoundMemberTy, UnresolvedTemplateTy,
       UnknownAnyTy;

--- a/clang/include/clang/AST/BuiltinTypes.def
+++ b/clang/include/clang/AST/BuiltinTypes.def
@@ -221,6 +221,19 @@ FLOATING_TYPE(Float128, Float128Ty)
 // '__ibm128'
 FLOATING_TYPE(Ibm128, Ibm128Ty)
 
+// '_Decimal32'
+FLOATING_TYPE(DecimalFloatBID32, DecimalFloat32Ty)
+FLOATING_TYPE(DecimalFloatDPD32, DecimalFloatDPD32Ty)
+
+// '_Decimal64'
+FLOATING_TYPE(DecimalFloatBID64, DecimalFloat64Ty)
+FLOATING_TYPE(DecimalFloatDPD64, DecimalFloatDPD64Ty)
+
+// '_Decimal128'
+FLOATING_TYPE(DecimalFloatBID128, DecimalFloat128Ty)
+FLOATING_TYPE(DecimalFloatDPD128, DecimalFloatDPD128Ty)
+
+
 //===- Language-specific types --------------------------------------------===//
 
 // This is the type of C++0x 'nullptr'.

--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -460,10 +460,10 @@ protected:
     unsigned : NumExprBits;
 
     static_assert(
-        llvm::APFloat::S_MaxSemantics < 16,
-        "Too many Semantics enum values to fit in bitfield of size 4");
+        llvm::APFloat::S_MaxSemantics < 32,
+        "Too many Semantics enum values to fit in bitfield of size 5");
     LLVM_PREFERRED_TYPE(llvm::APFloat::Semantics)
-    unsigned Semantics : 4; // Provides semantics for APFloat construction
+    unsigned Semantics : 5; // Provides semantics for APFloat construction
     LLVM_PREFERRED_TYPE(bool)
     unsigned IsExact : 1;
   };

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -2479,6 +2479,7 @@ public:
   bool isBFloat16Type() const;
   bool isFloat128Type() const;
   bool isIbm128Type() const;
+  bool isDecimalFloatType() const;
   bool isRealType() const;         // C99 6.2.5p17 (real floating + integer)
   bool isArithmeticType() const;   // C99 6.2.5p18 (integer + floating)
   bool isVoidType() const;         // C99 6.2.5p19

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -92,6 +92,9 @@ struct TransferrableTargetInfo {
   unsigned char FloatWidth, FloatAlign;
   unsigned char DoubleWidth, DoubleAlign;
   unsigned char LongDoubleWidth, LongDoubleAlign, Float128Align, Ibm128Align;
+  unsigned char DecimalFloat32Width, DecimalFloat32Align;
+  unsigned char DecimalFloat64Width, DecimalFloat64Align;
+  unsigned char DecimalFloat128Width, DecimalFloat128Align;
   unsigned char LargeArrayMinWidth, LargeArrayAlign;
   unsigned char LongWidth, LongAlign;
   unsigned char LongLongWidth, LongLongAlign;
@@ -136,7 +139,9 @@ struct TransferrableTargetInfo {
   unsigned MaxTLSAlign;
 
   const llvm::fltSemantics *HalfFormat, *BFloat16Format, *FloatFormat,
-      *DoubleFormat, *LongDoubleFormat, *Float128Format, *Ibm128Format;
+      *DoubleFormat, *LongDoubleFormat, *Float128Format, *Ibm128Format,
+      *DecimalFloatBID32Format, *DecimalFloatBID64Format, *DecimalFloatBID128Format,
+      *DecimalFloatDPD32Format, *DecimalFloatDPD64Format, *DecimalFloatDPD128Format;
 
   ///===---- Target Data Type Query Methods -------------------------------===//
   enum IntType {
@@ -793,6 +798,34 @@ public:
   const llvm::fltSemantics &getFloat128Format() const {
     return *Float128Format;
   }
+
+  unsigned getDecimalFloat32Width() const { return 32; }
+  unsigned getDecimalFloat32Align() const { return DecimalFloat32Align; }
+  const llvm::fltSemantics &getDecimalFloatBID32Format() const {
+    return *DecimalFloatBID32Format;
+  }
+  const llvm::fltSemantics &getDecimalFloatDPD32Format() const {
+    return *DecimalFloatDPD32Format;
+  }
+
+  unsigned getDecimalFloat64Width() const { return 64; }
+  unsigned getDecimalFloat64Align() const { return DecimalFloat64Align; }
+  const llvm::fltSemantics &getDecimalFloatBID64Format() const {
+    return *DecimalFloatBID64Format;
+  }
+  const llvm::fltSemantics &getDecimalFloatDPD64Format() const {
+    return *DecimalFloatDPD64Format;
+  }
+
+  unsigned getDecimalFloat128Width() const { return 128; }
+  unsigned getDecimalFloat128Align() const { return DecimalFloat128Align; }
+  const llvm::fltSemantics &getDecimalFloatBID128Format() const {
+    return *DecimalFloatBID128Format;
+  }
+  const llvm::fltSemantics &getDecimalFloatDPD128Format() const {
+    return *DecimalFloatDPD128Format;
+  }
+
 
   /// getIbm128Width/Align/Format - Return the size/align/format of
   /// '__ibm128'.

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -1263,6 +1263,14 @@ void ASTContext::InitBuiltinTypes(const TargetInfo &Target,
   InitBuiltinType(SatUnsignedFractTy,      BuiltinType::SatUFract);
   InitBuiltinType(SatUnsignedLongFractTy,  BuiltinType::SatULongFract);
 
+  InitBuiltinType(DecimalFloat32Ty, BuiltinType::DecimalFloatBID32);
+  InitBuiltinType(DecimalFloat64Ty, BuiltinType::DecimalFloatBID64);
+  InitBuiltinType(DecimalFloat128Ty, BuiltinType::DecimalFloatBID128);
+
+  InitBuiltinType(DecimalFloatDPD32Ty, BuiltinType::DecimalFloatDPD32);
+  InitBuiltinType(DecimalFloatDPD64Ty, BuiltinType::DecimalFloatDPD64);
+  InitBuiltinType(DecimalFloatDPD128Ty, BuiltinType::DecimalFloatDPD128);
+
   // GNU extension, 128-bit integers.
   InitBuiltinType(Int128Ty,            BuiltinType::Int128);
   InitBuiltinType(UnsignedInt128Ty,    BuiltinType::UInt128);
@@ -1628,6 +1636,18 @@ const llvm::fltSemantics &ASTContext::getFloatTypeSemantics(QualType T) const {
     if (getLangOpts().OpenMP && getLangOpts().OpenMPIsTargetDevice)
       return AuxTarget->getFloat128Format();
     return Target->getFloat128Format();
+  case BuiltinType::DecimalFloatBID32:
+    return Target->getDecimalFloatBID32Format();
+  case BuiltinType::DecimalFloatDPD32:
+    return Target->getDecimalFloatDPD32Format();
+  case BuiltinType::DecimalFloatBID64:
+    return Target->getDecimalFloatBID64Format();
+  case BuiltinType::DecimalFloatDPD64:
+    return Target->getDecimalFloatDPD64Format();
+  case BuiltinType::DecimalFloatBID128:
+    return Target->getDecimalFloatBID128Format();
+  case BuiltinType::DecimalFloatDPD128:
+    return Target->getDecimalFloatDPD128Format();  
   }
 }
 
@@ -2101,6 +2121,21 @@ TypeInfo ASTContext::getTypeInfoImpl(const Type *T) const {
     case BuiltinType::Ibm128:
       Width = Target->getIbm128Width();
       Align = Target->getIbm128Align();
+      break;
+    case BuiltinType::DecimalFloatBID32:
+    case BuiltinType::DecimalFloatDPD32:
+      Width = Target->getDecimalFloat32Width();
+      Align = Target->getDecimalFloat32Align();
+      break;  
+    case BuiltinType::DecimalFloatBID64:
+    case BuiltinType::DecimalFloatDPD64:
+      Width = Target->getDecimalFloat64Width();
+      Align = Target->getDecimalFloat64Align();
+      break;  
+    case BuiltinType::DecimalFloatBID128:
+    case BuiltinType::DecimalFloatDPD128:
+      Width = Target->getDecimalFloat128Width();
+      Align = Target->getDecimalFloat128Align();
       break;
     case BuiltinType::LongDouble:
       if (getLangOpts().OpenMP && getLangOpts().OpenMPIsTargetDevice &&
@@ -8140,6 +8175,12 @@ static char getObjCEncodingForPrimitiveType(const ASTContext *C,
     case BuiltinType::SatUShortFract:
     case BuiltinType::SatUFract:
     case BuiltinType::SatULongFract:
+    case BuiltinType::DecimalFloatBID32:
+    case BuiltinType::DecimalFloatDPD32:
+    case BuiltinType::DecimalFloatBID64:
+    case BuiltinType::DecimalFloatDPD64:
+    case BuiltinType::DecimalFloatBID128:
+    case BuiltinType::DecimalFloatDPD128:
       // FIXME: potentially need @encodes for these!
       return ' ';
 

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -2238,9 +2238,16 @@ bool Type::hasUnsignedIntegerRepresentation() const {
 bool Type::isFloatingType() const {
   if (const auto *BT = dyn_cast<BuiltinType>(CanonicalType))
     return BT->getKind() >= BuiltinType::Half &&
-           BT->getKind() <= BuiltinType::Ibm128;
+           BT->getKind() <= BuiltinType::DecimalFloatDPD128;
   if (const auto *CT = dyn_cast<ComplexType>(CanonicalType))
     return CT->getElementType()->isFloatingType();
+  return false;
+}
+
+bool Type::isDecimalFloatType() const {
+  if (const auto *BT = dyn_cast<BuiltinType>(CanonicalType))
+    return BT->getKind() >= BuiltinType::DecimalFloatBID32 &&
+           BT->getKind() <= BuiltinType::DecimalFloatDPD128;
   return false;
 }
 
@@ -2270,7 +2277,7 @@ bool Type::isRealType() const {
 bool Type::isArithmeticType() const {
   if (const auto *BT = dyn_cast<BuiltinType>(CanonicalType))
     return BT->getKind() >= BuiltinType::Bool &&
-           BT->getKind() <= BuiltinType::Ibm128;
+           BT->getKind() <= BuiltinType::DecimalFloatDPD128;
   if (const auto *ET = dyn_cast<EnumType>(CanonicalType))
     // GCC allows forward declaration of enum types (forbid by C99 6.7.2.3p2).
     // If a body isn't seen by the time we get here, return false.
@@ -3379,6 +3386,15 @@ StringRef BuiltinType::getName(const PrintingPolicy &Policy) const {
     return "__float128";
   case Ibm128:
     return "__ibm128";
+  case DecimalFloatBID32:
+  case DecimalFloatDPD32:
+    return "_Decimal32";
+  case DecimalFloatBID64:
+  case DecimalFloatDPD64:
+    return "_Decimal64";
+  case DecimalFloatBID128:
+  case DecimalFloatDPD128:
+    return "_Decimal128";
   case WChar_S:
   case WChar_U:
     return Policy.MSWChar ? "__wchar_t" : "wchar_t";

--- a/clang/lib/Basic/TargetInfo.cpp
+++ b/clang/lib/Basic/TargetInfo.cpp
@@ -147,6 +147,12 @@ TargetInfo::TargetInfo(const llvm::Triple &T) : Triple(T) {
   LongDoubleFormat = &llvm::APFloat::IEEEdouble();
   Float128Format = &llvm::APFloat::IEEEquad();
   Ibm128Format = &llvm::APFloat::PPCDoubleDouble();
+  DecimalFloatBID32Format = &llvm::APFloat::DFP32BID();
+  DecimalFloatBID64Format = &llvm::APFloat::DFP64BID();
+  DecimalFloatBID128Format = &llvm::APFloat::DFP128BID();
+  DecimalFloatDPD32Format = &llvm::APFloat::DFP32DPD();
+  DecimalFloatDPD64Format = &llvm::APFloat::DFP64DPD();
+  DecimalFloatDPD128Format = &llvm::APFloat::DFP128DPD();
   MCountName = "mcount";
   UserLabelPrefix = "_";
   RegParmMax = 0;

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -1170,11 +1170,13 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
     Result = Context.BoolTy; // _Bool or bool
     break;
   case DeclSpec::TST_decimal32:    // _Decimal32
+    Result = Context.DecimalFloat32Ty;
+    break;
   case DeclSpec::TST_decimal64:    // _Decimal64
+    Result = Context.DecimalFloat64Ty;
+    break;
   case DeclSpec::TST_decimal128:   // _Decimal128
-    S.Diag(DS.getTypeSpecTypeLoc(), diag::err_decimal_unsupported);
-    Result = Context.IntTy;
-    declarator.setInvalidType(true);
+    Result = Context.DecimalFloat128Ty;
     break;
   case DeclSpec::TST_class:
   case DeclSpec::TST_enum:

--- a/clang/test/AST/dfp.c
+++ b/clang/test/AST/dfp.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -x c -ast-dump %s | FileCheck %s --strict-whitespace
+
+_Decimal32 x;
+_Decimal64 y;
+_Decimal128 z;
+
+//CHECK:      |-VarDecl {{.*}} x '_Decimal32'
+//CHECK-NEXT: |-VarDecl {{.*}} y '_Decimal64'
+//CHECK-NEXT: `-VarDecl {{.*}} z '_Decimal128'

--- a/clang/test/Sema/types.c
+++ b/clang/test/Sema/types.c
@@ -48,7 +48,9 @@ enum e { e_1 };
 extern int j[sizeof(enum e)];  // expected-note {{previous declaration}}
 int j[42];   // expected-error {{redefinition of 'j' with a different type: 'int[42]' vs 'int[4]'}}
 
-_Decimal32 x;  // expected-error {{GNU decimal type extension not supported}}
+_Decimal32 x;
+_Decimal64 y;
+_Decimal128 z;
 
 int __attribute__ ((vector_size (8), vector_size (8))) v;  // expected-error {{invalid vector element type}}
 

--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -146,6 +146,12 @@ struct APFloatBase {
   /// A signed type to represent a floating point numbers unbiased exponent.
   typedef int32_t ExponentType;
 
+  enum RadixAndFormat {
+    BaseTwo,
+    BaseTenBID,
+    BaseTenDPD
+  };
+
   /// \name Floating Point Semantics.
   /// @{
   enum Semantics {
@@ -190,7 +196,13 @@ struct APFloatBase {
     S_FloatTF32,
 
     S_x87DoubleExtended,
-    S_MaxSemantics = S_x87DoubleExtended,
+    S_DFP32BID,
+    S_DFP32DPD,
+    S_DFP64BID,
+    S_DFP64DPD,
+    S_DFP128BID,
+    S_DFP128DPD,
+    S_MaxSemantics = S_DFP128DPD,
   };
 
   static const llvm::fltSemantics &EnumToSemantics(Semantics S);
@@ -209,6 +221,12 @@ struct APFloatBase {
   static const fltSemantics &Float8E4M3B11FNUZ() LLVM_READNONE;
   static const fltSemantics &FloatTF32() LLVM_READNONE;
   static const fltSemantics &x87DoubleExtended() LLVM_READNONE;
+  static const fltSemantics &DFP32BID() LLVM_READNONE;
+  static const fltSemantics &DFP32DPD() LLVM_READNONE;  
+  static const fltSemantics &DFP64BID() LLVM_READNONE;
+  static const fltSemantics &DFP64DPD() LLVM_READNONE;  
+  static const fltSemantics &DFP128BID() LLVM_READNONE;
+  static const fltSemantics &DFP128DPD() LLVM_READNONE;  
 
   /// A Pseudo fltsemantic used to construct APFloats that cannot conflict with
   /// anything real.
@@ -773,6 +791,354 @@ hash_code hash_value(const DoubleAPFloat &Arg);
 DoubleAPFloat scalbn(const DoubleAPFloat &Arg, int Exp, IEEEFloat::roundingMode RM);
 DoubleAPFloat frexp(const DoubleAPFloat &X, int &Exp, IEEEFloat::roundingMode);
 
+class DFPFloat final : public APFloatBase {
+public:
+  /// \name Constructors
+  /// @{
+
+  DFPFloat(const fltSemantics &) {} // Default construct to +0.0
+  DFPFloat(const fltSemantics &, integerPart) { assert(false && "Not Implemented"); }
+  DFPFloat(const fltSemantics &, uninitializedTag) { assert(false && "Not Implemented"); }
+  DFPFloat(const fltSemantics &, const APInt &) { assert(false && "Not Implemented"); }
+  explicit DFPFloat(double d) { assert(false && "Not Implemented"); }
+  explicit DFPFloat(float f) { assert(false && "Not Implemented"); }
+  DFPFloat(const DFPFloat &) { assert(false && "Not Implemented"); }
+  DFPFloat(DFPFloat &&) { assert(false && "Not Implemented"); }
+  ~DFPFloat() {}
+
+  /// @}
+
+  /// Returns whether this instance allocated memory.
+  bool needsCleanup() const { return partCount() > 1; }
+
+  
+  /// \name Arithmetic
+  /// @{
+
+  opStatus add(const DFPFloat &, roundingMode);
+  opStatus subtract(const DFPFloat &, roundingMode);
+  opStatus multiply(const DFPFloat &, roundingMode);
+  opStatus divide(const DFPFloat &, roundingMode);
+  
+  opStatus remainder(const DFPFloat &);
+  
+  opStatus mod(const DFPFloat &);
+  opStatus fusedMultiplyAdd(const DFPFloat &, const DFPFloat &, roundingMode);
+  opStatus roundToIntegral(roundingMode);
+ 
+  opStatus next(bool nextDown);
+
+  /// @}
+
+  /// \name Sign operations.
+  /// @{
+
+  void changeSign();
+
+  /// @}
+
+  /// \name Conversions
+  /// @{
+
+  opStatus convert(const fltSemantics &, roundingMode, bool *);
+  opStatus convertToInteger(MutableArrayRef<integerPart>, unsigned int, bool,
+                            roundingMode, bool *) const;
+  opStatus convertFromAPInt(const APInt &, bool, roundingMode);
+  opStatus convertFromSignExtendedInteger(const integerPart *, unsigned int,
+                                          bool, roundingMode);
+  opStatus convertFromZeroExtendedInteger(const integerPart *, unsigned int,
+                                          bool, roundingMode);
+  Expected<opStatus> convertFromString(StringRef, roundingMode);
+  APInt bitcastToAPInt() const;
+  double convertToDouble() const;
+  float convertToFloat() const;
+
+  /// @}
+
+  
+  bool operator==(const IEEEFloat &) const = delete;
+
+  
+  cmpResult compare(const IEEEFloat &) const;
+
+  
+  bool bitwiseIsEqual(const IEEEFloat &) const;
+
+  
+  unsigned int convertToHexString(char *dst, unsigned int hexDigits,
+                                  bool upperCase, roundingMode) const;
+
+ 
+  bool isNegative() const { return sign; }
+
+  
+  bool isNormal() const { return !isDenormal() && isFiniteNonZero(); }
+
+ 
+  bool isFinite() const { return !isNaN() && !isInfinity(); }
+
+  
+  bool isZero() const { return category == fcZero; }
+
+  
+  bool isDenormal() const;
+
+  
+  bool isInfinity() const { return category == fcInfinity; }
+
+  
+  bool isNaN() const { return category == fcNaN; }
+
+  
+  bool isSignaling() const;
+
+  /// @}
+
+  /// \name Simple Queries
+  /// @{
+
+  fltCategory getCategory() const { return category; }
+  const fltSemantics &getSemantics() const { return *semantics; }
+  bool isNonZero() const { return category != fcZero; }
+  bool isFiniteNonZero() const { return isFinite() && !isZero(); }
+  bool isPosZero() const { return isZero() && !isNegative(); }
+  bool isNegZero() const { return isZero() && isNegative(); }
+
+  /// Returns true if and only if the number has the smallest possible non-zero
+  /// magnitude in the current semantics.
+  bool isSmallest() const;
+
+  /// Returns true if this is the smallest (by magnitude) normalized finite
+  /// number in the given semantics.
+  bool isSmallestNormalized() const;
+
+  /// Returns true if and only if the number has the largest possible finite
+  /// magnitude in the current semantics.
+  bool isLargest() const;
+
+  /// Returns true if and only if the number is an exact integer.
+  bool isInteger() const;
+
+  /// @}
+
+  DFPFloat &operator=(const DFPFloat &);
+  DFPFloat &operator=(DFPFloat &&);
+
+  /// Overload to compute a hash code for an DFPFloat value.
+  ///
+  friend hash_code hash_value(const DFPFloat &Arg);
+
+  /// FIXME rewrite for DFP
+  /// Converts this value into a decimal string.
+  ///
+  /// \param FormatPrecision The maximum number of digits of
+  ///   precision to output.  If there are fewer digits available,
+  ///   zero padding will not be used unless the value is
+  ///   integral and small enough to be expressed in
+  ///   FormatPrecision digits.  0 means to use the natural
+  ///   precision of the number.
+  /// \param FormatMaxPadding The maximum number of zeros to
+  ///   consider inserting before falling back to scientific
+  ///   notation.  0 means to always use scientific notation.
+  ///
+  /// \param TruncateZero Indicate whether to remove the trailing zero in
+  ///   fraction part or not. Also setting this parameter to false forcing
+  ///   producing of output more similar to default printf behavior.
+  ///   Specifically the lower e is used as exponent delimiter and exponent
+  ///   always contains no less than two digits.
+  ///
+  /// Number       Precision    MaxPadding      Result
+  /// ------       ---------    ----------      ------
+  /// 1.01E+4              5             2       10100
+  /// 1.01E+4              4             2       1.01E+4
+  /// 1.01E+4              5             1       1.01E+4
+  /// 1.01E-2              5             2       0.0101
+  /// 1.01E-2              4             2       0.0101
+  /// 1.01E-2              4             1       1.01E-2
+  void toString(SmallVectorImpl<char> &Str, unsigned FormatPrecision = 0,
+                unsigned FormatMaxPadding = 3, bool TruncateZero = true) const;
+
+  /// If this value has an exact multiplicative inverse, store it in inv and
+  /// return true.
+  bool getExactInverse(DFPFloat *inv) const;
+
+  // If this is an exact power of two, return the exponent while ignoring the
+  // sign bit. If it's not an exact power of 2, return INT_MIN
+  LLVM_READONLY
+  int getExactLog2Abs() const;
+
+  // If this is an exact power of two, return the exponent. If it's not an exact
+  // power of 2, return INT_MIN
+  LLVM_READONLY
+  int getExactLog2() const {
+    return isNegative() ? INT_MIN : getExactLog2Abs();
+  }
+
+  
+  friend int ilogb(const DFPFloat &Arg);
+
+  
+  friend DFPFloat scalbn(DFPFloat X, int Exp, roundingMode);
+
+  friend DFPFloat frexp(const DFPFloat &X, int &Exp, roundingMode);
+
+  /// \name Special value setters.
+  /// @{
+
+  void makeLargest(bool Neg = false);
+  void makeSmallest(bool Neg = false);
+  void makeNaN(bool SNaN = false, bool Neg = false,
+               const APInt *fill = nullptr);
+  void makeInf(bool Neg = false);
+  void makeZero(bool Neg = false);
+  void makeQuiet();
+
+  /// Returns the smallest (by magnitude) normalized finite number in the given
+  /// semantics.
+  ///
+  /// \param Negative - True iff the number should be negative
+  void makeSmallestNormalized(bool Negative = false);
+
+  /// @}
+
+  cmpResult compareAbsoluteValue(const DFPFloat &) const;
+
+private:
+  /// \name Simple Queries
+  /// @{
+
+  integerPart *significandParts();
+  const integerPart *significandParts() const;
+  unsigned int partCount() const;
+
+  /// @}
+
+  /// \name Significand operations.
+  /// @{
+
+  integerPart addSignificand(const DFPFloat &);
+  integerPart subtractSignificand(const DFPFloat &, integerPart);
+  lostFraction addOrSubtractSignificand(const DFPFloat &, bool subtract);
+  lostFraction multiplySignificand(const DFPFloat &, DFPFloat);
+  lostFraction multiplySignificand(const DFPFloat&);
+  lostFraction divideSignificand(const DFPFloat &);
+  void incrementSignificand();
+  void initialize(const fltSemantics *);
+  void shiftSignificandLeft(unsigned int);
+  lostFraction shiftSignificandRight(unsigned int);
+  unsigned int significandLSB() const;
+  unsigned int significandMSB() const;
+  void zeroSignificand();
+  /// Return true if the significand excluding the integral bit is all ones.
+  bool isSignificandAllOnes() const;
+  bool isSignificandAllOnesExceptLSB() const;
+  /// Return true if the significand excluding the integral bit is all zeros.
+  bool isSignificandAllZeros() const;
+  bool isSignificandAllZerosExceptMSB() const;
+
+  /// @}
+
+  /// \name Arithmetic on special values.
+  /// @{
+
+  opStatus addOrSubtractSpecials(const DFPFloat &, bool subtract);
+  opStatus divideSpecials(const DFPFloat &);
+  opStatus multiplySpecials(const DFPFloat &);
+  opStatus modSpecials(const DFPFloat &);
+  opStatus remainderSpecials(const DFPFloat&);
+
+  /// @}
+
+  /// \name Miscellany
+  /// @{
+
+  bool convertFromStringSpecials(StringRef str);
+  opStatus normalize(roundingMode, lostFraction);
+  opStatus addOrSubtract(const DFPFloat &, roundingMode, bool subtract);
+  opStatus handleOverflow(roundingMode);
+  bool roundAwayFromZero(roundingMode, lostFraction, unsigned int) const;
+  opStatus convertToSignExtendedInteger(MutableArrayRef<integerPart>,
+                                        unsigned int, bool, roundingMode,
+                                        bool *) const;
+  opStatus convertFromUnsignedParts(const integerPart *, unsigned int,
+                                    roundingMode);
+  Expected<opStatus> convertFromHexadecimalString(StringRef, roundingMode);
+  Expected<opStatus> convertFromDecimalString(StringRef, roundingMode);
+  char *convertNormalToHexString(char *, unsigned int, bool,
+                                 roundingMode) const;
+  opStatus roundSignificandWithExponent(const integerPart *, unsigned int, int,
+                                        roundingMode);
+  ExponentType exponentNaN() const;
+  ExponentType exponentInf() const;
+  ExponentType exponentZero() const;
+
+  /// @}
+
+  template <const fltSemantics &S> APInt convertIEEEFloatToAPInt() const;
+  APInt convertHalfAPFloatToAPInt() const;
+  APInt convertBFloatAPFloatToAPInt() const;
+  APInt convertFloatAPFloatToAPInt() const;
+  APInt convertDoubleAPFloatToAPInt() const;
+  APInt convertQuadrupleAPFloatToAPInt() const;
+  APInt convertF80LongDoubleAPFloatToAPInt() const;
+  APInt convertPPCDoubleDoubleAPFloatToAPInt() const;
+  APInt convertFloat8E5M2APFloatToAPInt() const;
+  APInt convertFloat8E5M2FNUZAPFloatToAPInt() const;
+  APInt convertFloat8E4M3FNAPFloatToAPInt() const;
+  APInt convertFloat8E4M3FNUZAPFloatToAPInt() const;
+  APInt convertFloat8E4M3B11FNUZAPFloatToAPInt() const;
+  APInt convertFloatTF32APFloatToAPInt() const;
+  void initFromAPInt(const fltSemantics *Sem, const APInt &api);
+  template <const fltSemantics &S> void initFromIEEEAPInt(const APInt &api);
+  void initFromHalfAPInt(const APInt &api);
+  void initFromBFloatAPInt(const APInt &api);
+  void initFromFloatAPInt(const APInt &api);
+  void initFromDoubleAPInt(const APInt &api);
+  void initFromQuadrupleAPInt(const APInt &api);
+  void initFromF80LongDoubleAPInt(const APInt &api);
+  void initFromPPCDoubleDoubleAPInt(const APInt &api);
+  void initFromFloat8E5M2APInt(const APInt &api);
+  void initFromFloat8E5M2FNUZAPInt(const APInt &api);
+  void initFromFloat8E4M3FNAPInt(const APInt &api);
+  void initFromFloat8E4M3FNUZAPInt(const APInt &api);
+  void initFromFloat8E4M3B11FNUZAPInt(const APInt &api);
+  void initFromFloatTF32APInt(const APInt &api);
+
+  void assign(const DFPFloat &);
+  void copySignificand(const DFPFloat &);
+  void freeSignificand();
+
+  /// Note: this must be the first data member.
+  /// The semantics that this value obeys.
+  const fltSemantics *semantics;
+
+  /// A binary fraction with an explicit integer bit.
+  ///
+  /// The significand must be at least one bit wider than the target precision.
+  union Significand {
+    integerPart part;
+    integerPart *parts;
+  } significand;
+
+  /// The signed unbiased exponent of the value.
+  ExponentType exponent;
+
+  /// What kind of floating point number this is.
+  ///
+  /// Only 2 bits are required, but VisualStudio incorrectly sign extends it.
+  /// Using the extra bit keeps it from failing under VisualStudio.
+  fltCategory category : 3;
+
+  /// Sign bit of the number.
+  unsigned int sign : 1;
+};
+
+hash_code hash_value(const DFPFloat &Arg);
+int ilogb(const DFPFloat &Arg);
+DFPFloat scalbn(DFPFloat X, int Exp, DFPFloat::roundingMode);
+DFPFloat frexp(const DFPFloat &Val, int &Exp, DFPFloat::roundingMode RM);
+
+
 } // End detail namespace
 
 // This is a interface class that is currently forwarding functionalities from
@@ -780,6 +1146,7 @@ DoubleAPFloat frexp(const DoubleAPFloat &X, int &Exp, IEEEFloat::roundingMode);
 class APFloat : public APFloatBase {
   typedef detail::IEEEFloat IEEEFloat;
   typedef detail::DoubleAPFloat DoubleAPFloat;
+  typedef detail::DFPFloat DFPFloat;
 
   static_assert(std::is_standard_layout<IEEEFloat>::value);
 

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -60,6 +60,12 @@ public:
     X86_FP80TyID,  ///< 80-bit floating point type (X87)
     FP128TyID,     ///< 128-bit floating point type (112-bit significand)
     PPC_FP128TyID, ///< 128-bit floating point type (two 64-bits, PowerPC)
+    DecimalFloat32TyID,
+    DecimalFloatDPD32TyID,
+    DecimalFloat64TyID,
+    DecimalFloatDPD64TyID,
+    DecimalFloat128TyID,
+    DecimalFloatDPD128TyID,
     VoidTyID,      ///< type with no size
     LabelTyID,     ///< Labels
     MetadataTyID,  ///< Metadata

--- a/llvm/lib/IR/LLVMContextImpl.cpp
+++ b/llvm/lib/IR/LLVMContextImpl.cpp
@@ -41,7 +41,11 @@ LLVMContextImpl::LLVMContextImpl(LLVMContext &C)
       MetadataTy(C, Type::MetadataTyID), TokenTy(C, Type::TokenTyID),
       X86_FP80Ty(C, Type::X86_FP80TyID), FP128Ty(C, Type::FP128TyID),
       PPC_FP128Ty(C, Type::PPC_FP128TyID), X86_MMXTy(C, Type::X86_MMXTyID),
-      X86_AMXTy(C, Type::X86_AMXTyID), Int1Ty(C, 1), Int8Ty(C, 8),
+      X86_AMXTy(C, Type::X86_AMXTyID),
+      DecimalFloatBID32Ty(C, Type::DecimalFloat32TyID), DecimalFloatDPD32Ty(C, Type::DecimalFloatDPD32TyID),
+      DecimalFloatBID64Ty(C, Type::DecimalFloat64TyID), DecimalFloatDPD64Ty(C, Type::DecimalFloatDPD64TyID),
+      DecimalFloatBID128Ty(C, Type::DecimalFloat128TyID), DecimalFloatDPD128Ty(C, Type::DecimalFloatDPD128TyID),
+      Int1Ty(C, 1), Int8Ty(C, 8),
       Int16Ty(C, 16), Int32Ty(C, 32), Int64Ty(C, 64), Int128Ty(C, 128) {}
 
 LLVMContextImpl::~LLVMContextImpl() {

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -1573,6 +1573,8 @@ public:
   Type VoidTy, LabelTy, HalfTy, BFloatTy, FloatTy, DoubleTy, MetadataTy,
       TokenTy;
   Type X86_FP80Ty, FP128Ty, PPC_FP128Ty, X86_MMXTy, X86_AMXTy;
+  Type DecimalFloatBID32Ty, DecimalFloatBID64Ty, DecimalFloatBID128Ty;
+  Type DecimalFloatDPD32Ty, DecimalFloatDPD64Ty, DecimalFloatDPD128Ty;
   IntegerType Int1Ty, Int8Ty, Int16Ty, Int32Ty, Int64Ty, Int128Ty;
 
   std::unique_ptr<ConstantTokenNone> TheNoneToken;


### PR DESCRIPTION
This change starts the base set of changes to support DFP in APFloat and allow us to parse a DFP decalration and examine the AST.

Since we don't have a DFP implementation I avoided implementating much beyond the basics for APFloat.