### PR TITLE
[DFP] Initial changes to supprt DFP under APFloat and parse declarations

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -1101,7 +1101,7 @@ public:
   CanQualType HalfTy; // [OpenCL 6.1.1.1], ARM NEON
   CanQualType BFloat16Ty;
   CanQualType Float16Ty; // C11 extension ISO/IEC TS 18661-3
-  // ISO/IEC TS 18661-2:2015 c23 conditionally supported
+  // ISO/IEC TS 18661-2:2015, C23 conditionally supported
   CanQualType DecimalFloat32Ty, DecimalFloat64Ty, DecimalFloat128Ty;
   CanQualType VoidPtrTy, NullPtrTy;
   CanQualType DependentTy, OverloadTy, BoundMemberTy, UnknownAnyTy;

--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -1098,11 +1098,11 @@ public:
   CanQualType SatShortFractTy, SatFractTy, SatLongFractTy;
   CanQualType SatUnsignedShortFractTy, SatUnsignedFractTy,
       SatUnsignedLongFractTy;
-  // ISO/IEC TS 18661-2, ISO/IEC TR 24733, and C23 decimal floating-point.
-  CanQualType DecimalFloat32Ty, DecimalFloat64Ty, DecimalFloat128Ty;
   CanQualType HalfTy; // [OpenCL 6.1.1.1], ARM NEON
   CanQualType BFloat16Ty;
   CanQualType Float16Ty; // C11 extension ISO/IEC TS 18661-3
+  // ISO/IEC TS 18661-2:2015 c23 conditionally supported
+  CanQualType DecimalFloat32Ty, DecimalFloat64Ty, DecimalFloat128Ty;
   CanQualType VoidPtrTy, NullPtrTy;
   CanQualType DependentTy, OverloadTy, BoundMemberTy, UnknownAnyTy;
   CanQualType BuiltinFnTy;

--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -397,9 +397,9 @@ protected:
     unsigned : NumExprBits;
 
     static_assert(
-        llvm::APFloat::S_MaxSemantics < 16,
-        "Too many Semantics enum values to fit in bitfield of size 4");
-    unsigned Semantics : 4; // Provides semantics for APFloat construction
+        llvm::APFloat::S_MaxSemantics < 32,
+        "Too many Semantics enum values to fit in bitfield of size 5");
+    unsigned Semantics : 5; // Provides semantics for APFloat construction
     unsigned IsExact : 1;
   };
 

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -149,7 +149,8 @@ struct TransferrableTargetInfo {
   unsigned MaxTLSAlign;
 
   const llvm::fltSemantics *HalfFormat, *BFloat16Format, *FloatFormat,
-      *DoubleFormat, *LongDoubleFormat, *Float128Format, *Ibm128Format;
+      *DoubleFormat, *LongDoubleFormat, *Float128Format, *Ibm128Format,
+      *DecimalFloat32Format, *DecimalFloat64Format, *DecimalFloat128Format;
 
   ///===---- Target Data Type Query Methods -------------------------------===//
   enum IntType {
@@ -535,14 +536,23 @@ public:
   /// DecimalFloat32Width/Align - Return the size/align of '_Decimal32'.
   unsigned getDecimalFloat32Width() const { return DecimalFloat32Width; }
   unsigned getDecimalFloat32Align() const { return DecimalFloat32Align; }
+  const llvm::fltSemantics &getDecimalFloat32Format() const {
+    return *DecimalFloat32Format;
+  }
 
   /// DecimalFloat64Width/Align - Return the size/align of '_Decimal64'.
   unsigned getDecimalFloat64Width() const { return DecimalFloat64Width; }
   unsigned getDecimalFloat64Align() const { return DecimalFloat64Align; }
+  const llvm::fltSemantics &getDecimalFloat64Format() const {
+    return *DecimalFloat64Format;
+  }
 
   /// DecimalFloat128Width/Align - Return the size/align of '_Decimal128'.
   unsigned getDecimalFloat128Width() const { return DecimalFloat128Width; }
   unsigned getDecimalFloat128Align() const { return DecimalFloat128Align; }
+  const llvm::fltSemantics &getDecimalFloat128Format() const {
+    return *DecimalFloat128Format;
+  }
 
   /// getShortAccumWidth/Align - Return the size of 'signed short _Accum' and
   /// 'unsigned short _Accum' for this target, in bits.

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -1681,6 +1681,12 @@ const llvm::fltSemantics &ASTContext::getFloatTypeSemantics(QualType T) const {
     if (getLangOpts().OpenMP && getLangOpts().OpenMPIsTargetDevice)
       return AuxTarget->getFloat128Format();
     return Target->getFloat128Format();
+  case BuiltinType::DecimalFloat32:
+    return Target->getDecimalFloat32Format();
+  case BuiltinType::DecimalFloat64:
+    return Target->getDecimalFloat64Format();
+  case BuiltinType::DecimalFloat128:
+    return Target->getDecimalFloat128Format();
   }
 }
 

--- a/clang/lib/Basic/TargetInfo.cpp
+++ b/clang/lib/Basic/TargetInfo.cpp
@@ -152,9 +152,9 @@ TargetInfo::TargetInfo(const llvm::Triple &T) : Triple(T) {
   LongDoubleFormat = &llvm::APFloat::IEEEdouble();
   Float128Format = &llvm::APFloat::IEEEquad();
   Ibm128Format = &llvm::APFloat::PPCDoubleDouble();
-  DecimalFloat32Format = &llvm::APFloat::DFP32();
-  DecimalFloat64Format = &llvm::APFloat::DFP64();
-  DecimalFloat128Format = &llvm::APFloat::DFP128();
+  DecimalFloat32Format = &llvm::APFloat::DecimalFloat32();
+  DecimalFloat64Format = &llvm::APFloat::DecimalFloat64();
+  DecimalFloat128Format = &llvm::APFloat::DecimalFloat128();
   MCountName = "mcount";
   UserLabelPrefix = "_";
   RegParmMax = 0;

--- a/clang/lib/Basic/TargetInfo.cpp
+++ b/clang/lib/Basic/TargetInfo.cpp
@@ -152,6 +152,9 @@ TargetInfo::TargetInfo(const llvm::Triple &T) : Triple(T) {
   LongDoubleFormat = &llvm::APFloat::IEEEdouble();
   Float128Format = &llvm::APFloat::IEEEquad();
   Ibm128Format = &llvm::APFloat::PPCDoubleDouble();
+  DecimalFloat32Format = &llvm::APFloat::DFP32();
+  DecimalFloat64Format = &llvm::APFloat::DFP64();
+  DecimalFloat128Format = &llvm::APFloat::DFP128();
   MCountName = "mcount";
   UserLabelPrefix = "_";
   RegParmMax = 0;

--- a/clang/lib/CodeGen/CodeGenTypes.cpp
+++ b/clang/lib/CodeGen/CodeGenTypes.cpp
@@ -419,13 +419,13 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
       break;
 
     case BuiltinType::DecimalFloat32:
-      ResultType = llvm::Type::getDecimal32Ty(getLLVMContext());
+      ResultType = llvm::Type::getDecimalFloat32Ty(getLLVMContext());
       break;
     case BuiltinType::DecimalFloat64:
-      ResultType = llvm::Type::getDecimal64Ty(getLLVMContext());
+      ResultType = llvm::Type::getDecimalFloat64Ty(getLLVMContext());
       break;
     case BuiltinType::DecimalFloat128:
-      ResultType = llvm::Type::getDecimal128Ty(getLLVMContext());
+      ResultType = llvm::Type::getDecimalFloat128Ty(getLLVMContext());
       break;
 
     case BuiltinType::NullPtr:

--- a/clang/test/AST/dfp.c
+++ b/clang/test/AST/dfp.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -x c -ast-dump -fexperimental-decimal-floating-point %s | FileCheck %s --strict-whitespace
+
+_Decimal32 x;
+_Decimal64 y;
+_Decimal128 z;
+
+//CHECK:      |-VarDecl {{.*}} x '_Decimal32'
+//CHECK-NEXT: |-VarDecl {{.*}} y '_Decimal64'
+//CHECK-NEXT: `-VarDecl {{.*}} z '_Decimal128'

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -163,13 +163,13 @@ typedef enum {
   LLVMMetadataTypeKind,  /**< Metadata */
   LLVMX86_MMXTypeKind,   /**< X86 MMX */
   LLVMTokenTypeKind,     /**< Tokens */
-  LLVMScalableVectorTypeKind, /**< Scalable SIMD vector type */
-  LLVMBFloatTypeKind,         /**< 16 bit brain floating point type */
-  LLVMX86_AMXTypeKind,        /**< X86 AMX */
-  LLVMTargetExtTypeKind,      /**< Target extension type */
-  LLVMDecimal32TypeKind,      /**< 32 bit decimal floating point type */
-  LLVMDecimal64TypeKind,      /**< 64 bit decimal floating point type */
-  LLVMDecimal128TypeKind,     /**< 128 bit decimal floating point type */
+  LLVMScalableVectorTypeKind,  /**< Scalable SIMD vector type */
+  LLVMBFloatTypeKind,          /**< 16 bit brain floating point type */
+  LLVMX86_AMXTypeKind,         /**< X86 AMX */
+  LLVMTargetExtTypeKind,       /**< Target extension type */
+  LLVMDecimalFloat32TypeKind,  /**< 32 bit decimal floating point type */
+  LLVMDecimalFloat64TypeKind,  /**< 64 bit decimal floating point type */
+  LLVMDecimalFloat128TypeKind, /**< 128 bit decimal floating point type */
 } LLVMTypeKind;
 
 typedef enum {

--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -192,10 +192,10 @@ struct APFloatBase {
     S_FloatTF32,
 
     S_x87DoubleExtended,
-    S_DFP32,
-    S_DFP64,
-    S_DFP128,
-    S_MaxSemantics = S_DFP128,
+    S_DecimalFloat32,
+    S_DecimalFloat64,
+    S_DecimalFloat128,
+    S_MaxSemantics = S_DecimalFloat128,
   };
 
   static const llvm::fltSemantics &EnumToSemantics(Semantics S);
@@ -214,9 +214,9 @@ struct APFloatBase {
   static const fltSemantics &Float8E4M3B11FNUZ() LLVM_READNONE;
   static const fltSemantics &FloatTF32() LLVM_READNONE;
   static const fltSemantics &x87DoubleExtended() LLVM_READNONE;
-  static const fltSemantics &DFP32() LLVM_READNONE;
-  static const fltSemantics &DFP64() LLVM_READNONE;
-  static const fltSemantics &DFP128() LLVM_READNONE;
+  static const fltSemantics &DecimalFloat32() LLVM_READNONE;
+  static const fltSemantics &DecimalFloat64() LLVM_READNONE;
+  static const fltSemantics &DecimalFloat128() LLVM_READNONE;
 
   /// A Pseudo fltsemantic used to construct APFloats that cannot conflict with
   /// anything real.
@@ -804,54 +804,58 @@ public:
   /// \name Arithmetic
   /// @{
 
-  opStatus add(const DFPFloat &, roundingMode);
-  opStatus subtract(const DFPFloat &, roundingMode);
-  opStatus multiply(const DFPFloat &, roundingMode);
-  opStatus divide(const DFPFloat &, roundingMode);
+  // FIXME: Not implemented
+  opStatus add(const DFPFloat &, roundingMode) = delete;
+  opStatus subtract(const DFPFloat &, roundingMode) = delete;
+  opStatus multiply(const DFPFloat &, roundingMode) = delete;
+  opStatus divide(const DFPFloat &, roundingMode) = delete;
 
-  opStatus remainder(const DFPFloat &);
+  opStatus remainder(const DFPFloat &) = delete;
 
-  opStatus mod(const DFPFloat &);
-  opStatus fusedMultiplyAdd(const DFPFloat &, const DFPFloat &, roundingMode);
-  opStatus roundToIntegral(roundingMode);
+  opStatus mod(const DFPFloat &) = delete;
+  opStatus fusedMultiplyAdd(const DFPFloat &, const DFPFloat &, roundingMode) = delete;
+  opStatus roundToIntegral(roundingMode) = delete;
 
-  opStatus next(bool nextDown);
+  opStatus next(bool nextDown) = delete;
 
   /// @}
 
   /// \name Sign operations.
   /// @{
 
-  void changeSign();
+  void changeSign() = delete;
 
   /// @}
 
   /// \name Conversions
   /// @{
 
-  opStatus convert(const fltSemantics &, roundingMode, bool *);
+  opStatus convert(const fltSemantics &, roundingMode, bool *) = delete;
   opStatus convertToInteger(MutableArrayRef<integerPart>, unsigned int, bool,
-                            roundingMode, bool *) const;
+                            roundingMode, bool *) const = delete;
   opStatus convertFromAPInt(const APInt &, bool, roundingMode);
   opStatus convertFromSignExtendedInteger(const integerPart *, unsigned int,
-                                          bool, roundingMode);
+                                          bool, roundingMode) = delete;
   opStatus convertFromZeroExtendedInteger(const integerPart *, unsigned int,
-                                          bool, roundingMode);
+                                          bool, roundingMode) = delete;
   Expected<opStatus> convertFromString(StringRef, roundingMode);
   APInt bitcastToAPInt() const;
-  double convertToDouble() const;
-  float convertToFloat() const;
+  double convertToDouble() const = delete;
+  float convertToFloat() const = delete;
 
   /// @}
 
   bool operator==(const DFPFloat &) const = delete;
 
-  cmpResult compare(const DFPFloat &) const;
+  // Note: Non-canonical values are unordered with respect to other (non-canonical or canonical) equal values per IEEE 754:2008 5.10
+  cmpResult compare(const DFPFloat &) const = delete;
+  cmpResult compareAbsoluteValue(const DFPFloat &) const = delete;
+  cmpResult compareQuantum(const DFPFloat &) const = delete;
 
-  bool bitwiseIsEqual(const DFPFloat &) const;
+  bool bitwiseIsEqual(const DFPFloat &) const = delete;
 
   unsigned int convertToHexString(char *dst, unsigned int hexDigits,
-                                  bool upperCase, roundingMode) const;
+                                  bool upperCase, roundingMode) const = delete;
 
   bool isNegative() const { return sign; }
 
@@ -861,13 +865,14 @@ public:
 
   bool isZero() const { return category == fcZero; }
 
-  bool isDenormal() const;
+  bool isDenormal() const { return false;}
+  bool isNonCanonical() const = delete;
 
   bool isInfinity() const { return category == fcInfinity; }
 
   bool isNaN() const { return category == fcNaN; }
 
-  bool isSignaling() const;
+  bool isSignaling() const = delete;
 
   /// @}
 
@@ -883,23 +888,19 @@ public:
 
   /// Returns true if and only if the number has the smallest possible non-zero
   /// magnitude in the current semantics.
-  bool isSmallest() const;
-
-  /// Returns true if this is the smallest (by magnitude) normalized finite
-  /// number in the given semantics.
-  bool isSmallestNormalized() const;
+  bool isSmallest() const = delete;
 
   /// Returns true if and only if the number has the largest possible finite
   /// magnitude in the current semantics.
-  bool isLargest() const;
+  bool isLargest() const = delete;
 
   /// Returns true if and only if the number is an exact integer.
-  bool isInteger() const;
+  bool isInteger() const = delete;
 
   /// @}
 
-  DFPFloat &operator=(const DFPFloat &);
-  DFPFloat &operator=(DFPFloat &&);
+  DFPFloat &operator=(const DFPFloat &) = delete;
+  DFPFloat &operator=(DFPFloat &&) = delete;
 
   /// Overload to compute a hash code for an DFPFloat value.
   ///
@@ -937,46 +938,29 @@ public:
 
   /// If this value has an exact multiplicative inverse, store it in inv and
   /// return true.
-  bool getExactInverse(DFPFloat *inv) const;
+  bool getExactInverse(DFPFloat *inv) const = delete;
 
   // If this is an exact power of two, return the exponent while ignoring the
   // sign bit. If it's not an exact power of 2, return INT_MIN
   LLVM_READONLY
-  int getExactLog2Abs() const;
+  int getExactLog2Abs() const = delete;
 
-  // If this is an exact power of two, return the exponent. If it's not an exact
-  // power of 2, return INT_MIN
-  LLVM_READONLY
-  int getExactLog2() const {
-    return isNegative() ? INT_MIN : getExactLog2Abs();
-  }
-
-  friend int ilogb(const DFPFloat &Arg);
-
-  friend DFPFloat scalbn(DFPFloat X, int Exp, roundingMode);
-
-  friend DFPFloat frexp(const DFPFloat &X, int &Exp, roundingMode);
 
   /// \name Special value setters.
   /// @{
 
-  void makeLargest(bool Neg = false);
-  void makeSmallest(bool Neg = false);
+  void makeLargest(bool Neg = false) = delete;
+  void makeSmallest(bool Neg = false) = delete;
   void makeNaN(bool SNaN = false, bool Neg = false,
                const APInt *fill = nullptr);
   void makeInf(bool Neg = false);
   void makeZero(bool Neg = false);
-  void makeQuiet();
+  void makeQuiet() = delete;
 
-  /// Returns the smallest (by magnitude) normalized finite number in the given
-  /// semantics.
-  ///
-  /// \param Negative - True iff the number should be negative
-  void makeSmallestNormalized(bool Negative = false);
 
   /// @}
 
-  cmpResult compareAbsoluteValue(const DFPFloat &) const;
+  
 
 private:
   /// \name Simple Queries

--- a/llvm/include/llvm/IR/DataLayout.h
+++ b/llvm/include/llvm/IR/DataLayout.h
@@ -715,11 +715,11 @@ inline TypeSize DataLayout::getTypeSizeInBits(Type *Ty) const {
     Type *LayoutTy = cast<TargetExtType>(Ty)->getLayoutType();
     return getTypeSizeInBits(LayoutTy);
   }
-  case Type::Decimal32TyID:
+  case Type::DecimalFloat32TyID:
     return TypeSize::Fixed(32);
-  case Type::Decimal64TyID:
+  case Type::DecimalFloat64TyID:
     return TypeSize::Fixed(64);
-  case Type::Decimal128TyID:
+  case Type::DecimalFloat128TyID:
     return TypeSize::Fixed(128);
   default:
     llvm_unreachable("DataLayout::getTypeSizeInBits(): Unsupported type");

--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -547,19 +547,13 @@ public:
   }
 
   /// Fetch the type representing a 32-bit decimal floating point value.
-  Type *getDecimal32Ty() {
-    return Type::getDecimal32Ty(Context);
-  }
+  Type *getDecimalFloat32Ty() { return Type::getDecimalFloat32Ty(Context); }
 
   /// Fetch the type representing a 64-bit decimal floating point value.
-  Type *getDecimal64Ty() {
-    return Type::getDecimal64Ty(Context);
-  }
+  Type *getDecimalFloat64Ty() { return Type::getDecimalFloat64Ty(Context); }
 
   /// Fetch the type representing a 128-bit decimal floating point value.
-  Type *getDecimal128Ty() {
-    return Type::getDecimal128Ty(Context);
-  }
+  Type *getDecimalFloat128Ty() { return Type::getDecimalFloat128Ty(Context); }
 
   /// Fetch the type representing void.
   Type *getVoidTy() {

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -68,9 +68,9 @@ public:
     TokenTyID,     ///< Tokens
 
     // Decimal floating-point types.
-    Decimal32TyID, ///< 32-bit decimal floating point type
-    Decimal64TyID, ///< 64-bit decimal floating point type
-    Decimal128TyID, ///< 128-bit decimal floating point type
+    DecimalFloat32TyID,  ///< 32-bit decimal floating point type
+    DecimalFloat64TyID,  ///< 64-bit decimal floating point type
+    DecimalFloat128TyID, ///< 128-bit decimal floating point type
 
     // Derived types... see DerivedTypes.h file.
     IntegerTyID,        ///< Arbitrary bit width integers
@@ -171,18 +171,21 @@ public:
   bool isPPC_FP128Ty() const { return getTypeID() == PPC_FP128TyID; }
 
   /// Return true if this is 'decimal32'.
-  bool isDecimal32Ty() const { return getTypeID() == Decimal32TyID; }
+  bool isDecimalFloat32Ty() const { return getTypeID() == DecimalFloat32TyID; }
 
   /// Return true if this is 'decimal64'.
-  bool isDecimal64Ty() const { return getTypeID() == Decimal64TyID; }
+  bool isDecimalFloat64Ty() const { return getTypeID() == DecimalFloat64TyID; }
 
   /// Return true if this is 'decimal128'.
-  bool isDecimal128Ty() const { return getTypeID() == Decimal128TyID; }
+  bool isDecimalFloat128Ty() const {
+    return getTypeID() == DecimalFloat128TyID;
+  }
 
   /// Return true if this is a decimal floating point.
   bool isDecimalFloatingPointTy() const {
-    return getTypeID() == Decimal32TyID || getTypeID() == Decimal64TyID ||
-           getTypeID() == Decimal128TyID;
+    return getTypeID() == DecimalFloat32TyID ||
+           getTypeID() == DecimalFloat64TyID ||
+           getTypeID() == DecimalFloat128TyID;
   }
 
   /// Return true if this is a well-behaved IEEE-like type, which has a IEEE
@@ -488,9 +491,9 @@ public:
   static IntegerType *getInt32Ty(LLVMContext &C);
   static IntegerType *getInt64Ty(LLVMContext &C);
   static IntegerType *getInt128Ty(LLVMContext &C);
-  static Type *getDecimal32Ty(LLVMContext &C);
-  static Type *getDecimal64Ty(LLVMContext &C);
-  static Type *getDecimal128Ty(LLVMContext &C);
+  static Type *getDecimalFloat32Ty(LLVMContext &C);
+  static Type *getDecimalFloat64Ty(LLVMContext &C);
+  static Type *getDecimalFloat128Ty(LLVMContext &C);
   template <typename ScalarTy> static Type *getScalarTy(LLVMContext &C) {
     int noOfBits = sizeof(ScalarTy) * CHAR_BIT;
     if (std::is_integral<ScalarTy>::value) {

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -826,9 +826,9 @@ lltok::Kind LLLexer::LexIdentifier() {
   TYPEKEYWORD("x86_amx",   Type::getX86_AMXTy(Context));
   TYPEKEYWORD("token",     Type::getTokenTy(Context));
   TYPEKEYWORD("ptr",       PointerType::getUnqual(Context));
-  TYPEKEYWORD("decimal32", Type::getDecimal32Ty(Context));
-  TYPEKEYWORD("decimal64", Type::getDecimal64Ty(Context));
-  TYPEKEYWORD("decimal128", Type::getDecimal128Ty(Context));
+  TYPEKEYWORD("decimal32", Type::getDecimalFloat32Ty(Context));
+  TYPEKEYWORD("decimal64", Type::getDecimalFloat64Ty(Context));
+  TYPEKEYWORD("decimal128", Type::getDecimalFloat128Ty(Context));
 
 #undef TYPEKEYWORD
 

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -2509,13 +2509,13 @@ Error BitcodeReader::parseTypeTableBody() {
       break;
     }
     case bitc::TYPE_CODE_DECIMAL32: // 32-bit DFP
-      ResultTy = Type::getDecimal32Ty(Context);
+      ResultTy = Type::getDecimalFloat32Ty(Context);
       break;
     case bitc::TYPE_CODE_DECIMAL64: // 64-bit DFP
-      ResultTy = Type::getDecimal64Ty(Context);
+      ResultTy = Type::getDecimalFloat64Ty(Context);
       break;
     case bitc::TYPE_CODE_DECIMAL128: // 128-bit DFP
-      ResultTy = Type::getDecimal128Ty(Context);
+      ResultTy = Type::getDecimalFloat128Ty(Context);
       break;
     case bitc::TYPE_CODE_ARRAY:     // ARRAY: [numelts, eltty]
       if (Record.size() < 2)

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -976,9 +976,15 @@ void ModuleBitcodeWriter::writeTypeTable() {
     case Type::X86_FP80TyID:  Code = bitc::TYPE_CODE_X86_FP80;  break;
     case Type::FP128TyID:     Code = bitc::TYPE_CODE_FP128;     break;
     case Type::PPC_FP128TyID: Code = bitc::TYPE_CODE_PPC_FP128; break;
-    case Type::Decimal32TyID: Code = bitc::TYPE_CODE_DECIMAL32; break;
-    case Type::Decimal64TyID: Code = bitc::TYPE_CODE_DECIMAL64; break;
-    case Type::Decimal128TyID: Code = bitc::TYPE_CODE_DECIMAL128; break;
+    case Type::DecimalFloat32TyID:
+      Code = bitc::TYPE_CODE_DECIMAL32;
+      break;
+    case Type::DecimalFloat64TyID:
+      Code = bitc::TYPE_CODE_DECIMAL64;
+      break;
+    case Type::DecimalFloat128TyID:
+      Code = bitc::TYPE_CODE_DECIMAL128;
+      break;
     case Type::LabelTyID:     Code = bitc::TYPE_CODE_LABEL;     break;
     case Type::MetadataTyID:  Code = bitc::TYPE_CODE_METADATA;  break;
     case Type::X86_MMXTyID:   Code = bitc::TYPE_CODE_X86_MMX;   break;

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -561,9 +561,15 @@ void TypePrinting::print(Type *Ty, raw_ostream &OS) {
   case Type::IntegerTyID:
     OS << 'i' << cast<IntegerType>(Ty)->getBitWidth();
     return;
-  case Type::Decimal32TyID:  OS << "decimal32"; return;
-  case Type::Decimal64TyID:  OS << "decimal64"; return;
-  case Type::Decimal128TyID: OS << "decimal128"; return;
+  case Type::DecimalFloat32TyID:
+    OS << "decimal32";
+    return;
+  case Type::DecimalFloat64TyID:
+    OS << "decimal64";
+    return;
+  case Type::DecimalFloat128TyID:
+    OS << "decimal128";
+    return;
 
   case Type::FunctionTyID: {
     FunctionType *FTy = cast<FunctionType>(Ty);

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -563,12 +563,12 @@ LLVMTypeKind LLVMGetTypeKind(LLVMTypeRef Ty) {
     return LLVMFP128TypeKind;
   case Type::PPC_FP128TyID:
     return LLVMPPC_FP128TypeKind;
-  case Type::Decimal32TyID:
-    return LLVMDecimal32TypeKind;
-  case Type::Decimal64TyID:
-    return LLVMDecimal64TypeKind;
-  case Type::Decimal128TyID:
-    return LLVMDecimal128TypeKind;
+  case Type::DecimalFloat32TyID:
+    return LLVMDecimalFloat32TypeKind;
+  case Type::DecimalFloat64TyID:
+    return LLVMDecimalFloat64TypeKind;
+  case Type::DecimalFloat128TyID:
+    return LLVMDecimalFloat128TypeKind;
   case Type::LabelTyID:
     return LLVMLabelTypeKind;
   case Type::MetadataTyID:

--- a/llvm/lib/IR/LLVMContextImpl.cpp
+++ b/llvm/lib/IR/LLVMContextImpl.cpp
@@ -43,8 +43,9 @@ LLVMContextImpl::LLVMContextImpl(LLVMContext &C)
       PPC_FP128Ty(C, Type::PPC_FP128TyID), X86_MMXTy(C, Type::X86_MMXTyID),
       X86_AMXTy(C, Type::X86_AMXTyID), Int1Ty(C, 1), Int8Ty(C, 8),
       Int16Ty(C, 16), Int32Ty(C, 32), Int64Ty(C, 64), Int128Ty(C, 128),
-      Decimal32Ty(C, Type::Decimal32TyID), Decimal64Ty(C, Type::Decimal64TyID),
-      Decimal128Ty(C, Type::Decimal128TyID) {}
+      DecimalFloat32Ty(C, Type::DecimalFloat32TyID),
+      DecimalFloat64Ty(C, Type::DecimalFloat64TyID),
+      DecimalFloat128Ty(C, Type::DecimalFloat128TyID) {}
 
 LLVMContextImpl::~LLVMContextImpl() {
   // NOTE: We need to delete the contents of OwnedModules, but Module's dtor

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -1524,7 +1524,7 @@ public:
       TokenTy;
   Type X86_FP80Ty, FP128Ty, PPC_FP128Ty, X86_MMXTy, X86_AMXTy;
   IntegerType Int1Ty, Int8Ty, Int16Ty, Int32Ty, Int64Ty, Int128Ty;
-  Type Decimal32Ty, Decimal64Ty, Decimal128Ty;
+  Type DecimalFloat32Ty, DecimalFloat64Ty, DecimalFloat128Ty;
 
   std::unique_ptr<ConstantTokenNone> TheNoneToken;
 

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -48,9 +48,12 @@ Type *Type::getPrimitiveType(LLVMContext &C, TypeID IDNumber) {
   case X86_MMXTyID   : return getX86_MMXTy(C);
   case X86_AMXTyID   : return getX86_AMXTy(C);
   case TokenTyID     : return getTokenTy(C);
-  case Decimal32TyID :  return getDecimal32Ty(C);
-  case Decimal64TyID :  return getDecimal64Ty(C);
-  case Decimal128TyID: return getDecimal128Ty(C);
+  case DecimalFloat32TyID:
+    return getDecimalFloat32Ty(C);
+  case DecimalFloat64TyID:
+    return getDecimalFloat64Ty(C);
+  case DecimalFloat128TyID:
+    return getDecimalFloat128Ty(C);
   default:
     return nullptr;
   }
@@ -182,9 +185,12 @@ TypeSize Type::getPrimitiveSizeInBits() const {
   case Type::X86_FP80TyID: return TypeSize::Fixed(80);
   case Type::FP128TyID: return TypeSize::Fixed(128);
   case Type::PPC_FP128TyID: return TypeSize::Fixed(128);
-  case Decimal32TyID: return TypeSize::Fixed(32);
-  case Decimal64TyID: return TypeSize::Fixed(64);
-  case Decimal128TyID: return TypeSize::Fixed(128);
+  case DecimalFloat32TyID:
+    return TypeSize::Fixed(32);
+  case DecimalFloat64TyID:
+    return TypeSize::Fixed(64);
+  case DecimalFloat128TyID:
+    return TypeSize::Fixed(128);
   case Type::X86_MMXTyID: return TypeSize::Fixed(64);
   case Type::X86_AMXTyID: return TypeSize::Fixed(8192);
   case Type::IntegerTyID:
@@ -226,9 +232,12 @@ int Type::getDFPPrecisionInDigits() const {
   assert(isDecimalFloatingPointTy() && "Not a decimal floating point type!");
   // Precision values per the "Decimal interchange format parameters" table of
   /// C23 annex H.2.1, "Interchange floating types".
-  if (getTypeID() == Decimal32TyID) return 7;
-  if (getTypeID() == Decimal64TyID) return 16;
-  if (getTypeID() == Decimal128TyID) return 34;
+  if (getTypeID() == DecimalFloat32TyID)
+    return 7;
+  if (getTypeID() == DecimalFloat64TyID)
+    return 16;
+  if (getTypeID() == DecimalFloat128TyID)
+    return 34;
   report_fatal_error("unknown decimal floating point type");
 }
 
@@ -263,9 +272,15 @@ Type *Type::getPPC_FP128Ty(LLVMContext &C) { return &C.pImpl->PPC_FP128Ty; }
 Type *Type::getX86_MMXTy(LLVMContext &C) { return &C.pImpl->X86_MMXTy; }
 Type *Type::getX86_AMXTy(LLVMContext &C) { return &C.pImpl->X86_AMXTy; }
 
-Type *Type::getDecimal32Ty(LLVMContext &C) { return &C.pImpl->Decimal32Ty; }
-Type *Type::getDecimal64Ty(LLVMContext &C) { return &C.pImpl->Decimal64Ty; }
-Type *Type::getDecimal128Ty(LLVMContext &C) { return &C.pImpl->Decimal128Ty; }
+Type *Type::getDecimalFloat32Ty(LLVMContext &C) {
+  return &C.pImpl->DecimalFloat32Ty;
+}
+Type *Type::getDecimalFloat64Ty(LLVMContext &C) {
+  return &C.pImpl->DecimalFloat64Ty;
+}
+Type *Type::getDecimalFloat128Ty(LLVMContext &C) {
+  return &C.pImpl->DecimalFloat128Ty;
+}
 
 IntegerType *Type::getInt1Ty(LLVMContext &C) { return &C.pImpl->Int1Ty; }
 IntegerType *Type::getInt8Ty(LLVMContext &C) { return &C.pImpl->Int8Ty; }

--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -133,17 +133,21 @@ static constexpr fltSemantics semIEEEdouble = {1023, -1022, 53, 64};
 static constexpr fltSemantics semIEEEquad = {16383, -16382, 113, 128};
 static constexpr fltSemantics semFloat8E5M2 = {15, -14, 3, 8};
 // clang-format off
-static constexpr fltSemantics semFloat8E5M2FNUZ = {15,-15,3,8,APFloatBase::BaseTwo,fltNonfiniteBehavior::NanOnly,fltNanEncoding::NegativeZero};
-static constexpr fltSemantics semFloat8E4M3FN = {8,-6,4,8,APFloatBase::BaseTwo,fltNonfiniteBehavior::NanOnly,fltNanEncoding::AllOnes};
-static constexpr fltSemantics semFloat8E4M3FNUZ = {7,-7,4,8,APFloatBase::BaseTwo,fltNonfiniteBehavior::NanOnly,fltNanEncoding::NegativeZero};
-static constexpr fltSemantics semFloat8E4M3B11FNUZ = {4,-10,4,8,APFloatBase::BaseTwo,fltNonfiniteBehavior::NanOnly,fltNanEncoding::NegativeZero};
+static constexpr fltSemantics semFloat8E5M2FNUZ =
+  {15,-15,3,8,APFloatBase::BaseTwo,fltNonfiniteBehavior::NanOnly,fltNanEncoding::NegativeZero};
+static constexpr fltSemantics semFloat8E4M3FN =
+  {8,-6,4,8,APFloatBase::BaseTwo,fltNonfiniteBehavior::NanOnly,fltNanEncoding::AllOnes};
+static constexpr fltSemantics semFloat8E4M3FNUZ =
+  {7,-7,4,8,APFloatBase::BaseTwo,fltNonfiniteBehavior::NanOnly,fltNanEncoding::NegativeZero};
+static constexpr fltSemantics semFloat8E4M3B11FNUZ =
+  {4,-10,4,8,APFloatBase::BaseTwo,fltNonfiniteBehavior::NanOnly,fltNanEncoding::NegativeZero};
 static constexpr fltSemantics semFloatTF32 = {127, -126, 11, 19};
 static constexpr fltSemantics semX87DoubleExtended = {16383, -16382, 64, 80};
 static constexpr fltSemantics semBogus = {0, 0, 0, 0};
 // Values come from  "Decimal interchange format parameters" table in C23 H.2.1
 static constexpr fltSemantics semDFP32 = {97, -94, 7, 32, APFloatBase::BaseTen};
-static constexpr fltSemantics semDFP64 = {385, -382, 16, 64,APFloatBase::BaseTen};
-static constexpr fltSemantics semDFP128 = {6145, -6142, 34, 128,APFloatBase::BaseTen};
+static constexpr fltSemantics semDFP64 = {385, -382, 16, 64, APFloatBase::BaseTen};
+static constexpr fltSemantics semDFP128 = {6145, -6142, 34, 128, APFloatBase::BaseTen};
 // clang-format on
 
 /* The IBM double-double semantics. Such a number consists of a pair of IEEE

--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -132,46 +132,19 @@ static constexpr fltSemantics semIEEEsingle = {127, -126, 24, 32};
 static constexpr fltSemantics semIEEEdouble = {1023, -1022, 53, 64};
 static constexpr fltSemantics semIEEEquad = {16383, -16382, 113, 128};
 static constexpr fltSemantics semFloat8E5M2 = {15, -14, 3, 8};
-static constexpr fltSemantics semFloat8E5M2FNUZ = {
-    15,
-    -15,
-    3,
-    8,
-    APFloatBase::BaseTwo,
-    fltNonfiniteBehavior::NanOnly,
-    fltNanEncoding::NegativeZero};
-static constexpr fltSemantics semFloat8E4M3FN = {8,
-                                                 -6,
-                                                 4,
-                                                 8,
-                                                 APFloatBase::BaseTwo,
-                                                 fltNonfiniteBehavior::NanOnly,
-                                                 fltNanEncoding::AllOnes};
-static constexpr fltSemantics semFloat8E4M3FNUZ = {
-    7,
-    -7,
-    4,
-    8,
-    APFloatBase::BaseTwo,
-    fltNonfiniteBehavior::NanOnly,
-    fltNanEncoding::NegativeZero};
-static constexpr fltSemantics semFloat8E4M3B11FNUZ = {
-    4,
-    -10,
-    4,
-    8,
-    APFloatBase::BaseTwo,
-    fltNonfiniteBehavior::NanOnly,
-    fltNanEncoding::NegativeZero};
+// clang-format off
+static constexpr fltSemantics semFloat8E5M2FNUZ = {15,-15,3,8,APFloatBase::BaseTwo,fltNonfiniteBehavior::NanOnly,fltNanEncoding::NegativeZero};
+static constexpr fltSemantics semFloat8E4M3FN = {8,-6,4,8,APFloatBase::BaseTwo,fltNonfiniteBehavior::NanOnly,fltNanEncoding::AllOnes};
+static constexpr fltSemantics semFloat8E4M3FNUZ = {7,-7,4,8,APFloatBase::BaseTwo,fltNonfiniteBehavior::NanOnly,fltNanEncoding::NegativeZero};
+static constexpr fltSemantics semFloat8E4M3B11FNUZ = {4,-10,4,8,APFloatBase::BaseTwo,fltNonfiniteBehavior::NanOnly,fltNanEncoding::NegativeZero};
 static constexpr fltSemantics semFloatTF32 = {127, -126, 11, 19};
 static constexpr fltSemantics semX87DoubleExtended = {16383, -16382, 64, 80};
 static constexpr fltSemantics semBogus = {0, 0, 0, 0};
 // Values come from  "Decimal interchange format parameters" table in C23 H.2.1
 static constexpr fltSemantics semDFP32 = {97, -94, 7, 32, APFloatBase::BaseTen};
-static constexpr fltSemantics semDFP64 = {385, -382, 16, 64,
-                                          APFloatBase::BaseTen};
-static constexpr fltSemantics semDFP128 = {6145, -6142, 34, 128,
-                                           APFloatBase::BaseTen};
+static constexpr fltSemantics semDFP64 = {385, -382, 16, 64,APFloatBase::BaseTen};
+static constexpr fltSemantics semDFP128 = {6145, -6142, 34, 128,APFloatBase::BaseTen};
+// clang-format on
 
 /* The IBM double-double semantics. Such a number consists of a pair of IEEE
    64-bit doubles (Hi, Lo), where |Hi| > |Lo|, and if normal,
@@ -239,12 +212,12 @@ const llvm::fltSemantics &APFloatBase::EnumToSemantics(Semantics S) {
     return FloatTF32();
   case S_x87DoubleExtended:
     return x87DoubleExtended();
-  case S_DFP32:
-    return DFP32();
-  case S_DFP64:
-    return DFP64();
-  case S_DFP128:
-    return DFP128();
+  case S_DecimalFloat32:
+    return DecimalFloat32();
+  case S_DecimalFloat64:
+    return DecimalFloat64();
+  case S_DecimalFloat128:
+    return DecimalFloat128();
   }
   llvm_unreachable("Unrecognised floating semantics");
 }
@@ -277,12 +250,12 @@ APFloatBase::SemanticsToEnum(const llvm::fltSemantics &Sem) {
     return S_FloatTF32;
   else if (&Sem == &llvm::APFloat::x87DoubleExtended())
     return S_x87DoubleExtended;
-  else if (&Sem == &llvm::APFloat::DFP32())
-    return S_DFP32;
-  else if (&Sem == &llvm::APFloat::DFP64())
-    return S_DFP64;
-  else if (&Sem == &llvm::APFloat::DFP128())
-    return S_DFP128;
+  else if (&Sem == &llvm::APFloat::DecimalFloat32())
+    return S_DecimalFloat32;
+  else if (&Sem == &llvm::APFloat::DecimalFloat64())
+    return S_DecimalFloat64;
+  else if (&Sem == &llvm::APFloat::DecimalFloat128())
+    return S_DecimalFloat128;
   else
     llvm_unreachable("Unknown floating semantics");
 }
@@ -306,9 +279,9 @@ const fltSemantics &APFloatBase::FloatTF32() { return semFloatTF32; }
 const fltSemantics &APFloatBase::x87DoubleExtended() {
   return semX87DoubleExtended;
 }
-const fltSemantics &APFloatBase::DFP32() { return semDFP32; }
-const fltSemantics &APFloatBase::DFP64() { return semDFP64; }
-const fltSemantics &APFloatBase::DFP128() { return semDFP128; }
+const fltSemantics &APFloatBase::DecimalFloat32() { return semDFP32; }
+const fltSemantics &APFloatBase::DecimalFloat64() { return semDFP64; }
+const fltSemantics &APFloatBase::DecimalFloat128() { return semDFP128; }
 const fltSemantics &APFloatBase::Bogus() { return semBogus; }
 
 constexpr RoundingMode APFloatBase::rmNearestTiesToEven;


### PR DESCRIPTION
This change starts the base set of changes to support DFP in APFloat and allow us to parse a DFP decalration and examine the AST.

Since we don't have a DFP implementation I avoided implementating much beyond the basics for APFloat.