### PR TITLE
[SYCL] Improve kernel name diagnostic

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12197,7 +12197,7 @@ def err_sycl_entry_point_on_main : Error<
 def err_sycl_kernel_name_type : Error<
   "'sycl_kernel_entry_point' kernel name argument must be a class type">;
 def err_sycl_kernel_name_conflict : Error<
-  "'sycl_kernel_entry_point' kernel name argument conflicts with a previous"
+  "'sycl_kernel_entry_point' kernel name %0 conflicts with a previous"
   " declaration">;
 
 def warn_cuda_maxclusterrank_sm_90 : Warning<

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10348,6 +10348,8 @@ public:
       PrintPragmaAttributeInstantiationPoint();
   }
   void PrintInstantiationStack();
+  void
+      PrintInstantiationStack(std::function<void(const PartialDiagnosticAt &)>);
 
   /// Determines whether we are currently in a context where
   /// template argument substitution failures are not considered

--- a/clang/include/clang/Sema/SemaSYCL.h
+++ b/clang/include/clang/Sema/SemaSYCL.h
@@ -28,6 +28,10 @@ class SemaSYCL : public SemaBase {
 public:
   SemaSYCL(Sema &S);
 
+  using ContextNotes = SmallVector<PartialDiagnosticAt, 1>;
+  llvm::DenseMap<CanonicalDeclPtr<const FunctionDecl>, ContextNotes>
+      SYCLKernelEntryContextNotes;
+
   /// Creates a SemaDiagnosticBuilder that emits the diagnostic if the current
   /// context is "used as device code".
   ///

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -16069,9 +16069,9 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body,
       FD->setInvalidDecl();
     } else if (Body) {
       StmtResult SR = SYCL().BuildSYCLKernelCallStmt(FD, Body);
-      if (SR.isInvalid())
-        return nullptr;
-      Body = SR.get();
+      if (!SR.isInvalid()) {
+        Body = SR.get();
+      }
     }
   }
 

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -923,10 +923,16 @@ bool Sema::InstantiatingTemplate::CheckInstantiationDepth(
     << SemaRef.getLangOpts().InstantiationDepth;
   return true;
 }
-
+void Sema::PrintInstantiationStack() {
+  PrintInstantiationStack([&, this](const PartialDiagnosticAt &PD) {
+    DiagnosticBuilder Builder(Diags.Report(PD.first, PD.second.getDiagID()));
+    PD.second.Emit(Builder);
+  });
+}
 /// Prints the current instantiation stack through a series of
 /// notes.
-void Sema::PrintInstantiationStack() {
+void Sema::PrintInstantiationStack(
+    std::function<void(const PartialDiagnosticAt &)> EmitDiag) {
   // Determine which template instantiations to skip, if any.
   unsigned SkipStart = CodeSynthesisContexts.size(), SkipEnd = SkipStart;
   unsigned Limit = Diags.getTemplateBacktraceLimit();
@@ -946,9 +952,9 @@ void Sema::PrintInstantiationStack() {
     if (InstantiationIdx >= SkipStart && InstantiationIdx < SkipEnd) {
       if (InstantiationIdx == SkipStart) {
         // Note that we're skipping instantiations.
-        Diags.Report(Active->PointOfInstantiation,
-                     diag::note_instantiation_contexts_suppressed)
-          << unsigned(CodeSynthesisContexts.size() - Limit);
+        EmitDiag({Active->PointOfInstantiation,
+                  PDiag(diag::note_instantiation_contexts_suppressed)
+                      << unsigned(CodeSynthesisContexts.size() - Limit)});
       }
       continue;
     }
@@ -960,37 +966,34 @@ void Sema::PrintInstantiationStack() {
         unsigned DiagID = diag::note_template_member_class_here;
         if (isa<ClassTemplateSpecializationDecl>(Record))
           DiagID = diag::note_template_class_instantiation_here;
-        Diags.Report(Active->PointOfInstantiation, DiagID)
-          << Record << Active->InstantiationRange;
+        EmitDiag({Active->PointOfInstantiation,
+                  PDiag(DiagID) << Record << Active->InstantiationRange});
       } else if (FunctionDecl *Function = dyn_cast<FunctionDecl>(D)) {
         unsigned DiagID;
         if (Function->getPrimaryTemplate())
           DiagID = diag::note_function_template_spec_here;
         else
           DiagID = diag::note_template_member_function_here;
-        Diags.Report(Active->PointOfInstantiation, DiagID)
-          << Function
-          << Active->InstantiationRange;
+        EmitDiag({Active->PointOfInstantiation,
+                  PDiag(DiagID) << Function << Active->InstantiationRange});
       } else if (VarDecl *VD = dyn_cast<VarDecl>(D)) {
-        Diags.Report(Active->PointOfInstantiation,
-                     VD->isStaticDataMember()?
-                       diag::note_template_static_data_member_def_here
-                     : diag::note_template_variable_def_here)
-          << VD
-          << Active->InstantiationRange;
+        EmitDiag({Active->PointOfInstantiation,
+                  PDiag(VD->isStaticDataMember()
+                            ? diag::note_template_static_data_member_def_here
+                            : diag::note_template_variable_def_here)
+                      << VD << Active->InstantiationRange});
       } else if (EnumDecl *ED = dyn_cast<EnumDecl>(D)) {
-        Diags.Report(Active->PointOfInstantiation,
-                     diag::note_template_enum_def_here)
-          << ED
-          << Active->InstantiationRange;
+        EmitDiag({Active->PointOfInstantiation,
+                  PDiag(diag::note_template_enum_def_here)
+                      << ED << Active->InstantiationRange});
       } else if (FieldDecl *FD = dyn_cast<FieldDecl>(D)) {
-        Diags.Report(Active->PointOfInstantiation,
-                     diag::note_template_nsdmi_here)
-            << FD << Active->InstantiationRange;
+        EmitDiag({Active->PointOfInstantiation,
+                  PDiag(diag::note_template_nsdmi_here)
+                      << FD << Active->InstantiationRange});
       } else if (ClassTemplateDecl *CTD = dyn_cast<ClassTemplateDecl>(D)) {
-        Diags.Report(Active->PointOfInstantiation,
-                     diag::note_template_class_instantiation_here)
-            << CTD << Active->InstantiationRange;
+        EmitDiag({Active->PointOfInstantiation,
+                  PDiag(diag::note_template_class_instantiation_here)
+                      << CTD << Active->InstantiationRange});
       }
       break;
     }
@@ -1002,35 +1005,35 @@ void Sema::PrintInstantiationStack() {
       Template->printName(OS, getPrintingPolicy());
       printTemplateArgumentList(OS, Active->template_arguments(),
                                 getPrintingPolicy());
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_default_arg_instantiation_here)
-        << OS.str()
-        << Active->InstantiationRange;
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_default_arg_instantiation_here)
+                    << OS.str() << Active->InstantiationRange});
       break;
     }
 
     case CodeSynthesisContext::ExplicitTemplateArgumentSubstitution: {
       FunctionTemplateDecl *FnTmpl = cast<FunctionTemplateDecl>(Active->Entity);
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_explicit_template_arg_substitution_here)
-        << FnTmpl
-        << getTemplateArgumentBindingsText(FnTmpl->getTemplateParameters(),
-                                           Active->TemplateArgs,
-                                           Active->NumTemplateArgs)
-        << Active->InstantiationRange;
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_explicit_template_arg_substitution_here)
+                    << FnTmpl
+                    << getTemplateArgumentBindingsText(
+                           FnTmpl->getTemplateParameters(),
+                           Active->TemplateArgs, Active->NumTemplateArgs)
+                    << Active->InstantiationRange});
       break;
     }
 
     case CodeSynthesisContext::DeducedTemplateArgumentSubstitution: {
       if (FunctionTemplateDecl *FnTmpl =
               dyn_cast<FunctionTemplateDecl>(Active->Entity)) {
-        Diags.Report(Active->PointOfInstantiation,
-                     diag::note_function_template_deduction_instantiation_here)
-          << FnTmpl
-          << getTemplateArgumentBindingsText(FnTmpl->getTemplateParameters(),
-                                             Active->TemplateArgs,
-                                             Active->NumTemplateArgs)
-          << Active->InstantiationRange;
+        EmitDiag(
+            {Active->PointOfInstantiation,
+             PDiag(diag::note_function_template_deduction_instantiation_here)
+                 << FnTmpl
+                 << getTemplateArgumentBindingsText(
+                        FnTmpl->getTemplateParameters(), Active->TemplateArgs,
+                        Active->NumTemplateArgs)
+                 << Active->InstantiationRange});
       } else {
         bool IsVar = isa<VarTemplateDecl>(Active->Entity) ||
                      isa<VarTemplateSpecializationDecl>(Active->Entity);
@@ -1049,12 +1052,13 @@ void Sema::PrintInstantiationStack() {
           llvm_unreachable("unexpected template kind");
         }
 
-        Diags.Report(Active->PointOfInstantiation,
-                     diag::note_deduced_template_arg_substitution_here)
-          << IsVar << IsTemplate << cast<NamedDecl>(Active->Entity)
-          << getTemplateArgumentBindingsText(Params, Active->TemplateArgs,
-                                             Active->NumTemplateArgs)
-          << Active->InstantiationRange;
+        EmitDiag(
+            {Active->PointOfInstantiation,
+             PDiag(diag::note_deduced_template_arg_substitution_here)
+                 << IsVar << IsTemplate << cast<NamedDecl>(Active->Entity)
+                 << getTemplateArgumentBindingsText(
+                        Params, Active->TemplateArgs, Active->NumTemplateArgs)
+                 << Active->InstantiationRange});
       }
       break;
     }
@@ -1068,10 +1072,9 @@ void Sema::PrintInstantiationStack() {
       FD->printName(OS, getPrintingPolicy());
       printTemplateArgumentList(OS, Active->template_arguments(),
                                 getPrintingPolicy());
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_default_function_arg_instantiation_here)
-        << OS.str()
-        << Active->InstantiationRange;
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_default_function_arg_instantiation_here)
+                    << OS.str() << Active->InstantiationRange});
       break;
     }
 
@@ -1088,14 +1091,13 @@ void Sema::PrintInstantiationStack() {
         TemplateParams =
           cast<ClassTemplatePartialSpecializationDecl>(Active->Template)
                                                       ->getTemplateParameters();
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_prior_template_arg_substitution)
-        << isa<TemplateTemplateParmDecl>(Parm)
-        << Name
-        << getTemplateArgumentBindingsText(TemplateParams,
-                                           Active->TemplateArgs,
-                                           Active->NumTemplateArgs)
-        << Active->InstantiationRange;
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_prior_template_arg_substitution)
+                    << isa<TemplateTemplateParmDecl>(Parm) << Name
+                    << getTemplateArgumentBindingsText(TemplateParams,
+                                                       Active->TemplateArgs,
+                                                       Active->NumTemplateArgs)
+                    << Active->InstantiationRange});
       break;
     }
 
@@ -1108,55 +1110,56 @@ void Sema::PrintInstantiationStack() {
           cast<ClassTemplatePartialSpecializationDecl>(Active->Template)
                                                       ->getTemplateParameters();
 
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_template_default_arg_checking)
-        << getTemplateArgumentBindingsText(TemplateParams,
-                                           Active->TemplateArgs,
-                                           Active->NumTemplateArgs)
-        << Active->InstantiationRange;
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_template_default_arg_checking)
+                    << getTemplateArgumentBindingsText(TemplateParams,
+                                                       Active->TemplateArgs,
+                                                       Active->NumTemplateArgs)
+                    << Active->InstantiationRange});
       break;
     }
 
     case CodeSynthesisContext::ExceptionSpecEvaluation:
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_evaluating_exception_spec_here)
-          << cast<FunctionDecl>(Active->Entity);
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_evaluating_exception_spec_here)
+                    << cast<FunctionDecl>(Active->Entity)});
       break;
 
     case CodeSynthesisContext::ExceptionSpecInstantiation:
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_template_exception_spec_instantiation_here)
-        << cast<FunctionDecl>(Active->Entity)
-        << Active->InstantiationRange;
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_template_exception_spec_instantiation_here)
+                    << cast<FunctionDecl>(Active->Entity)
+                    << Active->InstantiationRange});
       break;
 
     case CodeSynthesisContext::RequirementInstantiation:
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_template_requirement_instantiation_here)
-        << Active->InstantiationRange;
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_template_requirement_instantiation_here)
+                    << Active->InstantiationRange});
       break;
     case CodeSynthesisContext::RequirementParameterInstantiation:
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_template_requirement_params_instantiation_here)
-          << Active->InstantiationRange;
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_template_requirement_params_instantiation_here)
+                    << Active->InstantiationRange});
       break;
 
     case CodeSynthesisContext::NestedRequirementConstraintsCheck:
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_nested_requirement_here)
-        << Active->InstantiationRange;
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_nested_requirement_here)
+                    << Active->InstantiationRange});
       break;
 
     case CodeSynthesisContext::DeclaringSpecialMember:
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_in_declaration_of_implicit_special_member)
-          << cast<CXXRecordDecl>(Active->Entity)
-          << llvm::to_underlying(Active->SpecialMember);
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_in_declaration_of_implicit_special_member)
+                    << cast<CXXRecordDecl>(Active->Entity)
+                    << llvm::to_underlying(Active->SpecialMember)});
       break;
 
     case CodeSynthesisContext::DeclaringImplicitEqualityComparison:
-      Diags.Report(Active->Entity->getLocation(),
-                   diag::note_in_declaration_of_implicit_equality_comparison);
+      EmitDiag(
+          {Active->Entity->getLocation(),
+           PDiag(diag::note_in_declaration_of_implicit_equality_comparison)});
       break;
 
     case CodeSynthesisContext::DefiningSynthesizedFunction: {
@@ -1167,60 +1170,62 @@ void Sema::PrintInstantiationStack() {
           FD ? getDefaultedFunctionKind(FD) : DefaultedFunctionKind();
       if (DFK.isSpecialMember()) {
         auto *MD = cast<CXXMethodDecl>(FD);
-        Diags.Report(Active->PointOfInstantiation,
-                     diag::note_member_synthesized_at)
-            << MD->isExplicitlyDefaulted()
-            << llvm::to_underlying(DFK.asSpecialMember())
-            << Context.getTagDeclType(MD->getParent());
+        EmitDiag({Active->PointOfInstantiation,
+                  PDiag(diag::note_member_synthesized_at)
+                      << MD->isExplicitlyDefaulted()
+                      << llvm::to_underlying(DFK.asSpecialMember())
+                      << Context.getTagDeclType(MD->getParent())});
       } else if (DFK.isComparison()) {
         QualType RecordType = FD->getParamDecl(0)
                                   ->getType()
                                   .getNonReferenceType()
                                   .getUnqualifiedType();
-        Diags.Report(Active->PointOfInstantiation,
-                     diag::note_comparison_synthesized_at)
-            << (int)DFK.asComparison() << RecordType;
+        EmitDiag({Active->PointOfInstantiation,
+                  PDiag(diag::note_comparison_synthesized_at)
+                      << (int)DFK.asComparison() << RecordType});
       }
       break;
     }
 
     case CodeSynthesisContext::RewritingOperatorAsSpaceship:
-      Diags.Report(Active->Entity->getLocation(),
-                   diag::note_rewriting_operator_as_spaceship);
+      EmitDiag({Active->Entity->getLocation(),
+                PDiag(diag::note_rewriting_operator_as_spaceship)});
       break;
 
     case CodeSynthesisContext::InitializingStructuredBinding:
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_in_binding_decl_init)
-          << cast<BindingDecl>(Active->Entity);
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_in_binding_decl_init)
+                    << cast<BindingDecl>(Active->Entity)});
       break;
 
     case CodeSynthesisContext::MarkingClassDllexported:
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_due_to_dllexported_class)
-          << cast<CXXRecordDecl>(Active->Entity) << !getLangOpts().CPlusPlus11;
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_due_to_dllexported_class)
+                    << cast<CXXRecordDecl>(Active->Entity)
+                    << !getLangOpts().CPlusPlus11});
       break;
 
     case CodeSynthesisContext::BuildingBuiltinDumpStructCall:
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_building_builtin_dump_struct_call)
-          << convertCallArgsToString(
-                 *this, llvm::ArrayRef(Active->CallArgs, Active->NumCallArgs));
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_building_builtin_dump_struct_call)
+                    << convertCallArgsToString(
+                           *this, llvm::ArrayRef(Active->CallArgs,
+                                                 Active->NumCallArgs))});
       break;
 
     case CodeSynthesisContext::Memoization:
       break;
 
     case CodeSynthesisContext::LambdaExpressionSubstitution:
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_lambda_substitution_here);
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_lambda_substitution_here)});
       break;
     case CodeSynthesisContext::ConstraintsCheck: {
       unsigned DiagID = 0;
       if (!Active->Entity) {
-        Diags.Report(Active->PointOfInstantiation,
-                     diag::note_nested_requirement_here)
-          << Active->InstantiationRange;
+        EmitDiag({Active->PointOfInstantiation,
+                  PDiag(diag::note_nested_requirement_here)
+                      << Active->InstantiationRange});
         break;
       }
       if (isa<ConceptDecl>(Active->Entity))
@@ -1242,35 +1247,35 @@ void Sema::PrintInstantiationStack() {
         printTemplateArgumentList(OS, Active->template_arguments(),
                                   getPrintingPolicy());
       }
-      Diags.Report(Active->PointOfInstantiation, DiagID) << OS.str()
-        << Active->InstantiationRange;
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(DiagID) << OS.str() << Active->InstantiationRange});
       break;
     }
     case CodeSynthesisContext::ConstraintSubstitution:
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_constraint_substitution_here)
-          << Active->InstantiationRange;
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_constraint_substitution_here)
+                    << Active->InstantiationRange});
       break;
     case CodeSynthesisContext::ConstraintNormalization:
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_constraint_normalization_here)
-          << cast<NamedDecl>(Active->Entity)->getName()
-          << Active->InstantiationRange;
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_constraint_normalization_here)
+                    << cast<NamedDecl>(Active->Entity)->getName()
+                    << Active->InstantiationRange});
       break;
     case CodeSynthesisContext::ParameterMappingSubstitution:
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_parameter_mapping_substitution_here)
-          << Active->InstantiationRange;
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_parameter_mapping_substitution_here)
+                    << Active->InstantiationRange});
       break;
     case CodeSynthesisContext::BuildingDeductionGuides:
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_building_deduction_guide_here);
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_building_deduction_guide_here)});
       break;
     case CodeSynthesisContext::TypeAliasTemplateInstantiation:
-      Diags.Report(Active->PointOfInstantiation,
-                   diag::note_template_type_alias_instantiation_here)
-          << cast<TypeAliasTemplateDecl>(Active->Entity)
-          << Active->InstantiationRange;
+      EmitDiag({Active->PointOfInstantiation,
+                PDiag(diag::note_template_type_alias_instantiation_here)
+                    << cast<TypeAliasTemplateDecl>(Active->Entity)
+                    << Active->InstantiationRange});
       break;
     }
   }


### PR DESCRIPTION
In case of conflicting SYCL kernel name, the compiler reported the location of the initial kernel but without any context. This lead to a poor diagnostic when used with template as the user had no information on how the initial kernel was instantiated.

A second issue can arise with SFINAE as the name validation was done during overload resolution when the attribute is used on a templated function. This lead to the attribute interfering with the overload resolution.

We now record the template instantiation trace when a SYCL entry point is registered. In case of conflicting name, the diagnostic is issue when emitting the SYCL kernel CallStmt and the trace is looked up to provide the full context.