### PR TITLE
Refactor diagnostics for sycl_kernel_entry_point

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12297,7 +12297,7 @@ def err_sycl_entry_point_invalid_redeclaration : Error<
   "'sycl_kernel_entry_point' kernel name argument does not match prior"
   " declaration%diff{: $ vs $|}0,1">;
 def err_sycl_kernel_name_conflict : Error<
-  "'sycl_kernel_entry_point' kernel name argument conflicts with a previous"
+  "'sycl_kernel_entry_point' kernel name %0 conflicts with a previous"
   " declaration">;
 def warn_sycl_kernel_name_not_a_class_type : Warning<
   "%0 is not a valid SYCL kernel name type; a class type is required">,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -13237,6 +13237,8 @@ public:
   /// Prints the current instantiation stack through a series of
   /// notes.
   void PrintInstantiationStack();
+  void
+      PrintInstantiationStack(std::function<void(const PartialDiagnosticAt &)>);
 
   /// Determines whether we are currently in a context where
   /// template argument substitution failures are not considered

--- a/clang/include/clang/Sema/SemaSYCL.h
+++ b/clang/include/clang/Sema/SemaSYCL.h
@@ -28,6 +28,10 @@ class SemaSYCL : public SemaBase {
 public:
   SemaSYCL(Sema &S);
 
+  using ContextNotes = SmallVector<PartialDiagnosticAt, 1>;
+  llvm::DenseMap<CanonicalDeclPtr<const FunctionDecl>, ContextNotes>
+      SYCLKernelEntryContextNotes;
+
   /// Creates a SemaDiagnosticBuilder that emits the diagnostic if the current
   /// context is "used as device code".
   ///

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -15862,33 +15862,32 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body,
       CheckCoroutineWrapper(FD);
   }
 
-  // Create SYCL kernel entry point function outline.
-  if (FD && !FD->isInvalidDecl() && !FD->isDependentContext() &&
-      FD->hasAttr<SYCLKernelEntryPointAttr>()) {
-    if (FD->isDeleted()) {
-      Diag(FD->getAttr<SYCLKernelEntryPointAttr>()->getLocation(),
-           diag::err_sycl_entry_point_invalid)
-          << /*deleted function*/2;
-      FD->setInvalidDecl();
-    } else if (FD->isDefaulted()) {
-      Diag(FD->getAttr<SYCLKernelEntryPointAttr>()->getLocation(),
-           diag::err_sycl_entry_point_invalid)
-          << /*defaulted function*/3;
-      FD->setInvalidDecl();
-    } else if (FSI->isCoroutine()) {
-      Diag(FD->getAttr<SYCLKernelEntryPointAttr>()->getLocation(),
-           diag::err_sycl_entry_point_invalid)
-          << /*coroutine*/7;
-      FD->setInvalidDecl();
-    }
-  }
-
   {
     // Do not call PopExpressionEvaluationContext() if it is a lambda because
     // one is already popped when finishing the lambda in BuildLambdaExpr().
     // This is meant to pop the context added in ActOnStartOfFunctionDef().
     ExitFunctionBodyRAII ExitRAII(*this, isLambdaCallOperator(FD));
     if (FD) {
+      // Create SYCL kernel entry point function outline.
+      if (!FD->isInvalidDecl() && !FD->isDependentContext() &&
+          FD->hasAttr<SYCLKernelEntryPointAttr>()) {
+        if (FD->isDeleted()) {
+          Diag(FD->getAttr<SYCLKernelEntryPointAttr>()->getLocation(),
+              diag::err_sycl_entry_point_invalid)
+              << /*deleted function*/2;
+          FD->setInvalidDecl();
+        } else if (FD->isDefaulted()) {
+          Diag(FD->getAttr<SYCLKernelEntryPointAttr>()->getLocation(),
+              diag::err_sycl_entry_point_invalid)
+              << /*defaulted function*/3;
+          FD->setInvalidDecl();
+        } else if (FSI->isCoroutine()) {
+          Diag(FD->getAttr<SYCLKernelEntryPointAttr>()->getLocation(),
+              diag::err_sycl_entry_point_invalid)
+              << /*coroutine*/7;
+          FD->setInvalidDecl();
+        }
+      }
       // If this is called by Parser::ParseFunctionDefinition() after marking
       // the declaration as deleted, and if the deleted-function-body contains
       // a message (C++26), then a DefaultedOrDeletedInfo will have already been

--- a/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-appertainment.cpp
+++ b/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-appertainment.cpp
@@ -103,7 +103,7 @@ const void ok11();
 ////////////////////////////////////////////////////////////////////////////////
 
 struct Smain;
-// expected-error@+1 {{'main' cannot be declared with the 'sycl_kernel_entry_point' attribute}}
+// expected-error@+1 {{'sycl_kernel_entry_point' attribute only applies to functions with a 'void' return type}}
 [[clang::sycl_kernel_entry_point(Smain)]]
 int main();
 


### PR DESCRIPTION
Make them more precise by providing better context and avoid false overload resolution errors.

retargeted PR from https://github.com/tahonermann/llvm-project/pull/45, not addressing https://github.com/tahonermann/llvm-project/pull/45#discussion_r1783795735 yet