### PR TITLE
[DFP] Implement parsing of Decimal32 literals and printing of Decimal32 values

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -1098,11 +1098,11 @@ public:
   CanQualType SatShortFractTy, SatFractTy, SatLongFractTy;
   CanQualType SatUnsignedShortFractTy, SatUnsignedFractTy,
       SatUnsignedLongFractTy;
-  // ISO/IEC TS 18661-2, ISO/IEC TR 24733, and C23 decimal floating-point.
-  CanQualType DecimalFloat32Ty, DecimalFloat64Ty, DecimalFloat128Ty;
   CanQualType HalfTy; // [OpenCL 6.1.1.1], ARM NEON
   CanQualType BFloat16Ty;
   CanQualType Float16Ty; // C11 extension ISO/IEC TS 18661-3
+  // ISO/IEC TS 18661-2:2015 c23 conditionally supported
+  CanQualType DecimalFloat32Ty, DecimalFloat64Ty, DecimalFloat128Ty;
   CanQualType VoidPtrTy, NullPtrTy;
   CanQualType DependentTy, OverloadTy, BoundMemberTy, UnknownAnyTy;
   CanQualType BuiltinFnTy;

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -1661,9 +1661,10 @@ public:
 
 class FloatingLiteral : public Expr, private APFloatStorage {
   SourceLocation Loc;
+  bool DFP : 1;
 
   FloatingLiteral(const ASTContext &C, const llvm::APFloat &V, bool isexact,
-                  QualType Type, SourceLocation L);
+                  QualType Type, SourceLocation L, bool isDFP=false);
 
   /// Construct an empty floating-point literal.
   explicit FloatingLiteral(const ASTContext &C, EmptyShell Empty);
@@ -1673,6 +1674,7 @@ public:
                                  bool isexact, QualType Type, SourceLocation L);
   static FloatingLiteral *Create(const ASTContext &C, EmptyShell Empty);
 
+  bool isDFP() const { return DFP; }
   llvm::APFloat getValue() const {
     return APFloatStorage::getValue(getSemantics());
   }
@@ -1713,6 +1715,10 @@ public:
   /// double.  Note that this may cause loss of precision, but is useful for
   /// debugging dumps, etc.
   double getValueAsApproximateDouble() const;
+
+  void getValueAsString(SmallVectorImpl<char> &Str) const {
+    getValue().toString(Str,0,0,false);
+  }
 
   SourceLocation getLocation() const { return Loc; }
   void setLocation(SourceLocation L) { Loc = L; }

--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -397,9 +397,9 @@ protected:
     unsigned : NumExprBits;
 
     static_assert(
-        llvm::APFloat::S_MaxSemantics < 16,
-        "Too many Semantics enum values to fit in bitfield of size 4");
-    unsigned Semantics : 4; // Provides semantics for APFloat construction
+        llvm::APFloat::S_MaxSemantics < 32,
+        "Too many Semantics enum values to fit in bitfield of size 5");
+    unsigned Semantics : 5; // Provides semantics for APFloat construction
     unsigned IsExact : 1;
   };
 

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -149,7 +149,8 @@ struct TransferrableTargetInfo {
   unsigned MaxTLSAlign;
 
   const llvm::fltSemantics *HalfFormat, *BFloat16Format, *FloatFormat,
-      *DoubleFormat, *LongDoubleFormat, *Float128Format, *Ibm128Format;
+      *DoubleFormat, *LongDoubleFormat, *Float128Format, *Ibm128Format,
+      *DecimalFloat32Format, *DecimalFloat64Format, *DecimalFloat128Format;
 
   ///===---- Target Data Type Query Methods -------------------------------===//
   enum IntType {
@@ -535,14 +536,23 @@ public:
   /// DecimalFloat32Width/Align - Return the size/align of '_Decimal32'.
   unsigned getDecimalFloat32Width() const { return DecimalFloat32Width; }
   unsigned getDecimalFloat32Align() const { return DecimalFloat32Align; }
+  const llvm::fltSemantics &getDecimalFloat32Format() const {
+    return *DecimalFloat32Format;
+  }
 
   /// DecimalFloat64Width/Align - Return the size/align of '_Decimal64'.
   unsigned getDecimalFloat64Width() const { return DecimalFloat64Width; }
   unsigned getDecimalFloat64Align() const { return DecimalFloat64Align; }
+  const llvm::fltSemantics &getDecimalFloat64Format() const {
+    return *DecimalFloat64Format;
+  }
 
   /// DecimalFloat128Width/Align - Return the size/align of '_Decimal128'.
   unsigned getDecimalFloat128Width() const { return DecimalFloat128Width; }
   unsigned getDecimalFloat128Align() const { return DecimalFloat128Align; }
+  const llvm::fltSemantics &getDecimalFloat128Format() const {
+    return *DecimalFloat128Format;
+  }
 
   /// getShortAccumWidth/Align - Return the size of 'signed short _Accum' and
   /// 'unsigned short _Accum' for this target, in bits.

--- a/clang/include/clang/Lex/LiteralSupport.h
+++ b/clang/include/clang/Lex/LiteralSupport.h
@@ -60,7 +60,7 @@ class NumericLiteralParser {
 
   unsigned radix;
 
-  bool saw_exponent, saw_period, saw_ud_suffix, saw_fixed_point_suffix;
+  bool saw_exponent, saw_period, saw_ud_suffix, saw_fixed_point_suffix, saw_decimal_float_suffix;
 
   SmallString<32> UDSuffixBuf;
 
@@ -78,6 +78,11 @@ public:
   bool isImaginary : 1;     // 1.0i
   bool isFloat16 : 1;       // 1.0f16
   bool isFloat128 : 1;      // 1.0q
+  bool isDecimalFloat : 1;  // df/DF for _Decimal32, dd/DD for _Decimal64
+                            // Dl/DL for _Decimal128
+  bool isDecimal32 : 1;     // 6543.0DF
+  bool isDecimal64 : 1;     // 9.99DD
+  bool isDecimal128 : 1;    // 9.99DL
   bool isFract : 1;         // 1.0hr/r/lr/uhr/ur/ulr
   bool isAccum : 1;         // 1.0hk/k/lk/uhk/uk/ulk
   bool isBitInt : 1;        // 1wb, 1uwb (C23)
@@ -86,6 +91,10 @@ public:
 
   bool isFixedPointLiteral() const {
     return (saw_period || saw_exponent) && saw_fixed_point_suffix;
+  }
+
+  bool isDecimalFloatLiteral() const {
+    return (saw_period || saw_exponent) && saw_decimal_float_suffix;
   }
 
   bool isIntegerLiteral() const {
@@ -123,6 +132,11 @@ public:
   /// set to true if the returned APFloat can represent the number in the
   /// literal exactly, and false otherwise.
   llvm::APFloat::opStatus GetFloatValue(llvm::APFloat &Result);
+
+  /// GetDecimalFloatValue - Convert this numeric literal to a decimal float value, using
+  /// the specified DFPFloat fltSemantics (specifying _Decimal32, _Decimal64, etc).
+  llvm::APFloat::opStatus GetDecimalFloatValue(llvm::APFloat &Result);
+
 
   /// GetFixedPointValue - Convert this numeric literal value into a
   /// scaled integer that represents this value. Returns true if an overflow

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -1681,6 +1681,12 @@ const llvm::fltSemantics &ASTContext::getFloatTypeSemantics(QualType T) const {
     if (getLangOpts().OpenMP && getLangOpts().OpenMPIsTargetDevice)
       return AuxTarget->getFloat128Format();
     return Target->getFloat128Format();
+  case BuiltinType::DecimalFloat32:
+    return Target->getDecimalFloat32Format();
+  case BuiltinType::DecimalFloat64:
+    return Target->getDecimalFloat64Format();
+  case BuiltinType::DecimalFloat128:
+    return Target->getDecimalFloat128Format();
   }
 }
 

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -1083,8 +1083,8 @@ void CharacterLiteral::print(unsigned Val, CharacterKind Kind,
 }
 
 FloatingLiteral::FloatingLiteral(const ASTContext &C, const llvm::APFloat &V,
-                                 bool isexact, QualType Type, SourceLocation L)
-    : Expr(FloatingLiteralClass, Type, VK_PRValue, OK_Ordinary), Loc(L) {
+                                 bool isexact, QualType Type, SourceLocation L, bool isDFP)
+    : Expr(FloatingLiteralClass, Type, VK_PRValue, OK_Ordinary), Loc(L), DFP(isDFP) {
   setSemantics(V.getSemantics());
   FloatingLiteralBits.IsExact = isexact;
   setValue(C, V);
@@ -1100,7 +1100,7 @@ FloatingLiteral::FloatingLiteral(const ASTContext &C, EmptyShell Empty)
 FloatingLiteral *
 FloatingLiteral::Create(const ASTContext &C, const llvm::APFloat &V,
                         bool isexact, QualType Type, SourceLocation L) {
-  return new (C) FloatingLiteral(C, V, isexact, Type, L);
+  return new (C) FloatingLiteral(C, V, isexact, Type, L, V.isDFP());
 }
 
 FloatingLiteral *

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -1208,7 +1208,13 @@ void TextNodeDumper::VisitFixedPointLiteral(const FixedPointLiteral *Node) {
 
 void TextNodeDumper::VisitFloatingLiteral(const FloatingLiteral *Node) {
   ColorScope Color(OS, ShowColors, ValueColor);
-  OS << " " << Node->getValueAsApproximateDouble();
+  if (!Node->isDFP())
+    OS << " " << Node->getValueAsApproximateDouble();
+  else {
+    SmallVector<char, 16> Buffer;
+    Node->getValueAsString(Buffer);
+    OS << " " << Buffer;
+  }
 }
 
 void TextNodeDumper::VisitStringLiteral(const StringLiteral *Str) {

--- a/clang/lib/Basic/TargetInfo.cpp
+++ b/clang/lib/Basic/TargetInfo.cpp
@@ -152,6 +152,9 @@ TargetInfo::TargetInfo(const llvm::Triple &T) : Triple(T) {
   LongDoubleFormat = &llvm::APFloat::IEEEdouble();
   Float128Format = &llvm::APFloat::IEEEquad();
   Ibm128Format = &llvm::APFloat::PPCDoubleDouble();
+  DecimalFloat32Format = &llvm::APFloat::DFP32();
+  DecimalFloat64Format = &llvm::APFloat::DFP64();
+  DecimalFloat128Format = &llvm::APFloat::DFP128();
   MCountName = "mcount";
   UserLabelPrefix = "_";
   RegParmMax = 0;

--- a/clang/lib/CodeGen/CodeGenTypes.cpp
+++ b/clang/lib/CodeGen/CodeGenTypes.cpp
@@ -419,13 +419,13 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
       break;
 
     case BuiltinType::DecimalFloat32:
-      ResultType = llvm::Type::getDecimal32Ty(getLLVMContext());
+      ResultType = llvm::Type::getDecimalFloat32Ty(getLLVMContext());
       break;
     case BuiltinType::DecimalFloat64:
-      ResultType = llvm::Type::getDecimal64Ty(getLLVMContext());
+      ResultType = llvm::Type::getDecimalFloat64Ty(getLLVMContext());
       break;
     case BuiltinType::DecimalFloat128:
-      ResultType = llvm::Type::getDecimal128Ty(getLLVMContext());
+      ResultType = llvm::Type::getDecimalFloat128Ty(getLLVMContext());
       break;
 
     case BuiltinType::NullPtr:

--- a/clang/test/AST/dfp.c
+++ b/clang/test/AST/dfp.c
@@ -6,4 +6,35 @@ _Decimal128 z;
 
 //CHECK:      |-VarDecl {{.*}} x '_Decimal32'
 //CHECK-NEXT: |-VarDecl {{.*}} y '_Decimal64'
-//CHECK-NEXT: `-VarDecl {{.*}} z '_Decimal128'
+//CHECK-NEXT: |-VarDecl {{.*}} z '_Decimal128'
+
+void f(void) {
+  _Decimal32 x = 0.0DF;
+  _Decimal32 x2 = 1234.0DF;
+  _Decimal32 x3 = 945.75DF;
+  _Decimal32 x4 = 1E-6DF; // DEC32_EPSILON
+  _Decimal32 x5 = 9.999999E40DF;
+  _Decimal32 x6 = 100000.0DF;
+  _Decimal32 x7 = 9.999999E96DF; // DEC32_MAX
+  _Decimal32 x8 = 1E-95DF; // DEC32_MIN
+  _Decimal32 x9 = 0.000001E-95DF; // DEC32_TRUE_MIN
+}
+
+//CHECK:      | `-VarDecl {{.*}} x '_Decimal32'
+//CHECK-NEXT: |   `-FloatingLiteral {{.*}} '_Decimal32' 0E+0 
+//CHECK:      | `-VarDecl {{.*}} x2 '_Decimal32'
+//CHECK-NEXT: |   `-FloatingLiteral {{.*}} '_Decimal32' 12340E-1 
+//CHECK:      | `-VarDecl {{.*}} x3 '_Decimal32'
+//CHECK-NEXT: |   `-FloatingLiteral {{.*}} '_Decimal32' 94575E-2
+//CHECK:      | `-VarDecl {{.*}} x4 '_Decimal32'
+//CHECK-NEXT: |   `-FloatingLiteral {{.*}} '_Decimal32' 1E-6
+//CHECK:      | `-VarDecl {{.*}} x5 '_Decimal32'
+//CHECK-NEXT: |   `-FloatingLiteral {{.*}} '_Decimal32' 9999999E+34
+//CHECK:      | `-VarDecl {{.*}} x6 '_Decimal32'
+//CHECK-NEXT: |   `-FloatingLiteral {{.*}} '_Decimal32' 1000000E-1
+//CHECK:      | `-VarDecl {{.*}} x7 '_Decimal32'
+//CHECK-NEXT: |   `-FloatingLiteral {{.*}} '_Decimal32' 9999999E+90 
+//CHECK:      | `-VarDecl {{.*}} x8 '_Decimal32'
+//CHECK-NEXT: |   `-FloatingLiteral {{.*}} '_Decimal32' 1E-95 
+//CHECK:        `-VarDecl {{.*}} x9 '_Decimal32'
+//CHECK-NEXT:     `-FloatingLiteral {{.*}} '_Decimal32' 1E-11 

--- a/clang/test/AST/dfp.c
+++ b/clang/test/AST/dfp.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -x c -ast-dump -fexperimental-decimal-floating-point %s | FileCheck %s --strict-whitespace
+
+_Decimal32 x;
+_Decimal64 y;
+_Decimal128 z;
+
+//CHECK:      |-VarDecl {{.*}} x '_Decimal32'
+//CHECK-NEXT: |-VarDecl {{.*}} y '_Decimal64'
+//CHECK-NEXT: `-VarDecl {{.*}} z '_Decimal128'

--- a/llvm/include/llvm-c/Core.h
+++ b/llvm/include/llvm-c/Core.h
@@ -163,13 +163,13 @@ typedef enum {
   LLVMMetadataTypeKind,  /**< Metadata */
   LLVMX86_MMXTypeKind,   /**< X86 MMX */
   LLVMTokenTypeKind,     /**< Tokens */
-  LLVMScalableVectorTypeKind, /**< Scalable SIMD vector type */
-  LLVMBFloatTypeKind,         /**< 16 bit brain floating point type */
-  LLVMX86_AMXTypeKind,        /**< X86 AMX */
-  LLVMTargetExtTypeKind,      /**< Target extension type */
-  LLVMDecimal32TypeKind,      /**< 32 bit decimal floating point type */
-  LLVMDecimal64TypeKind,      /**< 64 bit decimal floating point type */
-  LLVMDecimal128TypeKind,     /**< 128 bit decimal floating point type */
+  LLVMScalableVectorTypeKind,  /**< Scalable SIMD vector type */
+  LLVMBFloatTypeKind,          /**< 16 bit brain floating point type */
+  LLVMX86_AMXTypeKind,         /**< X86 AMX */
+  LLVMTargetExtTypeKind,       /**< Target extension type */
+  LLVMDecimalFloat32TypeKind,  /**< 32 bit decimal floating point type */
+  LLVMDecimalFloat64TypeKind,  /**< 64 bit decimal floating point type */
+  LLVMDecimalFloat128TypeKind, /**< 128 bit decimal floating point type */
 } LLVMTypeKind;
 
 typedef enum {

--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -33,6 +33,15 @@
     llvm_unreachable("Unexpected semantics");                                  \
   } while (false)
 
+  #define APFLOAT_NO_DFP_DISPATCH_ON_SEMANTICS(METHOD_CALL)                             \
+  do {                                                                         \
+    if (usesLayout<IEEEFloat>(getSemantics()))                                 \
+      return U.IEEE.METHOD_CALL;                                               \
+    if (usesLayout<DoubleAPFloat>(getSemantics()))                             \
+      return U.Double.METHOD_CALL;                                             \
+    llvm_unreachable("Unexpected semantics");                                  \
+  } while (false)
+
 namespace llvm {
 
 struct fltSemantics;
@@ -804,39 +813,39 @@ public:
   /// @{
 
   // FIXME: Not implemented
-  opStatus add(const DFPFloat &, roundingMode) = delete;
-  opStatus subtract(const DFPFloat &, roundingMode) = delete;
-  opStatus multiply(const DFPFloat &, roundingMode) = delete;
-  opStatus divide(const DFPFloat &, roundingMode) = delete;
+  opStatus add(const DFPFloat &, roundingMode) { assert(false && "Not implemented"); }
+  opStatus subtract(const DFPFloat &, roundingMode) { assert(false && "Not implemented"); }
+  opStatus multiply(const DFPFloat &, roundingMode) { assert(false && "Not implemented"); }
+  opStatus divide(const DFPFloat &, roundingMode) { assert(false && "Not implemented"); }
 
-  opStatus remainder(const DFPFloat &) = delete;
+  opStatus remainder(const DFPFloat &) { assert(false && "Not implemented"); }
 
-  opStatus mod(const DFPFloat &) = delete;
-  opStatus fusedMultiplyAdd(const DFPFloat &, const DFPFloat &, roundingMode) = delete;
-  opStatus roundToIntegral(roundingMode) = delete;
+  opStatus mod(const DFPFloat &) { assert(false && "Not implemented"); }
+  opStatus fusedMultiplyAdd(const DFPFloat &, const DFPFloat &, roundingMode) { assert(false && "Not implemented"); }
+  opStatus roundToIntegral(roundingMode) { assert( false && "Not implemented"); };
 
-  opStatus next(bool nextDown) = delete;
+  opStatus next(bool nextDown) { assert( false && "Not Implemented"); };
 
   /// @}
 
   /// \name Sign operations.
   /// @{
 
-  void changeSign() = delete;
+  void changeSign();
 
   /// @}
 
   /// \name Conversions
   /// @{
 
-  opStatus convert(const fltSemantics &, roundingMode, bool *) = delete;
+  opStatus convert(const fltSemantics &, roundingMode, bool *) { assert(false && "Not implemented"); }
   opStatus convertToInteger(MutableArrayRef<integerPart>, unsigned int, bool,
-                            roundingMode, bool *) const = delete;
-  opStatus convertFromAPInt(const APInt &, bool, roundingMode);
+                            roundingMode, bool *) const { assert(false && "Not Implemented"); }
+  opStatus convertFromAPInt(const APInt &, bool, roundingMode) { assert(false && "Not Implemented"); }
   opStatus convertFromSignExtendedInteger(const integerPart *, unsigned int,
-                                          bool, roundingMode) = delete;
+                                          bool, roundingMode) { assert(false && "Not Implemented"); }
   opStatus convertFromZeroExtendedInteger(const integerPart *, unsigned int,
-                                          bool, roundingMode) = delete;
+                                          bool, roundingMode) { assert(false && "Not Implemented"); }
   Expected<opStatus> convertFromString(StringRef, roundingMode);
   Expected<opStatus> convertFromStringDFP32(StringRef, roundingMode);
   Expected<opStatus> convertFromStringDFP64(StringRef, roundingMode);
@@ -847,22 +856,21 @@ public:
   template <const fltSemantics &S>
   APInt convertDFPToAPInt() const;
   
-  double convertToDouble() const = delete  { assert(false && "Not Implemented"); }
-  float convertToFloat() const = delete  { assert(false && "Not Implemented"); }
-
+  double convertToDouble() const { assert(false && "Not implemented"); }
+  float convertToFloat() const { assert(false && "Not implemented"); }
   /// @}
 
-  bool operator==(const DFPFloat &) const = delete;
+  bool operator==(const DFPFloat &) = delete;
 
   // Note: Non-canonical values are unordered with respect to other (non-canonical or canonical) equal values per IEEE 754:2008 5.10
-  cmpResult compare(const DFPFloat &) const = delete;
-  cmpResult compareAbsoluteValue(const DFPFloat &) const = delete;
-  cmpResult compareQuantum(const DFPFloat &) const = delete;
+  cmpResult compare(const DFPFloat &) const { assert(false && "Not implemented"); }
+  cmpResult compareAbsoluteValue(const DFPFloat &) const { assert(false && "Not implemented"); }
+  cmpResult compareQuantum(const DFPFloat &) const { assert(false && "Not implemented"); }
 
-  bool bitwiseIsEqual(const DFPFloat &) const = delete;
+  bool bitwiseIsEqual(const DFPFloat &) const { assert(false && "Not implemented"); }
 
   unsigned int convertToHexString(char *dst, unsigned int hexDigits,
-                                  bool upperCase, roundingMode) const = delete;
+                                  bool upperCase, roundingMode) const { assert(false && "Not Implemented"); }
 
   bool isNegative() const { return sign; }
 
@@ -895,19 +903,22 @@ public:
 
   /// Returns true if and only if the number has the smallest possible non-zero
   /// magnitude in the current semantics.
-  bool isSmallest() const = delete;
+  bool isSmallest() const  { assert(false && "Not Implemented"); }
+
 
   /// Returns true if and only if the number has the largest possible finite
   /// magnitude in the current semantics.
-  bool isLargest() const = delete;
+  bool isLargest() const  { assert(false && "Not Implemented"); }
+
 
   /// Returns true if and only if the number is an exact integer.
-  bool isInteger() const = delete;
+  bool isInteger() const  { assert(false && "Not Implemented"); }
+
 
   /// @}
 
-  DFPFloat &operator=(const DFPFloat &) = delete;
-  DFPFloat &operator=(DFPFloat &&) = delete;
+  DFPFloat &operator=(const DFPFloat &) { assert(false && "Not Implemented"); }
+  DFPFloat &operator=(DFPFloat &&){ assert(false && "Not Implemented"); }
 
   /// Overload to compute a hash code for an DFPFloat value.
   ///
@@ -951,26 +962,29 @@ public:
 
   /// If this value has an exact multiplicative inverse, store it in inv and
   /// return true.
-  bool getExactInverse(DFPFloat *inv) const = delete;
+  bool getExactInverse(DFPFloat *inv) const  { assert(false && "Not Implemented"); }
+
 
   // If this is an exact power of two, return the exponent while ignoring the
   // sign bit. If it's not an exact power of 2, return INT_MIN
   LLVM_READONLY
-  int getExactLog2Abs() const = delete;
+  int getExactLog2Abs() const  { assert(false && "Not Implemented"); }
+
 
 
   /// \name Special value setters.
   /// @{
 
-  void makeLargest(bool Neg = false) = delete { assert(false && "Not Implemented"); }
-  void makeSmallest(bool Neg = false) = delete { assert(false && "Not Implemented"); }
+  void makeLargest(bool Neg = false) { assert(false && "Not implemented"); }
+  void makeSmallest(bool Neg = false) { assert(false && "Not implemented"); }
   void makeNaN(bool SNaN = false, bool Neg = false, const APInt *fill = nullptr);
   void makeInf(bool Neg = false, bool ExplicitPlus = false);
   void makeZero(bool Neg = false);
   void makeZeroInternalDFP32(bool Neg = false, int right_of_radix_leading_zero=0);
   void makeZeroInternalDFP64(bool Neg = false, int right_of_radix_leading_zero=0);
   void makeZeroInternalDFP128(bool Neg = false, int right_of_radix_leading_zero=0);
-  void makeQuiet() = delete;
+  void makeQuiet()  { assert(false && "Not Implemented"); }
+
 
 
   /// @}
@@ -1177,9 +1191,9 @@ class APFloat : public APFloatBase {
              &Semantics == &IEEEquad();
  
     } else if (std::is_same<T, DFPFloat>::value) {
-      return &Semantics == &DFP32() ||
-             &Semantics == &DFP64() ||
-             &Semantics == &DFP128();
+      return &Semantics == &DecimalFloat32() ||
+             &Semantics == &DecimalFloat64() ||
+             &Semantics == &DecimalFloat128();
     }
      llvm_unreachable("Unexpected semantics");
   }
@@ -1217,7 +1231,7 @@ class APFloat : public APFloatBase {
   }
 
   void makeSmallestNormalized(bool Neg) {
-    APFLOAT_DISPATCH_ON_SEMANTICS(makeSmallestNormalized(Neg));
+    APFLOAT_NO_DFP_DISPATCH_ON_SEMANTICS(makeSmallestNormalized(Neg));
   }
 
   explicit APFloat(IEEEFloat F, const fltSemantics &S) : U(std::move(F), S) {}
@@ -1617,7 +1631,7 @@ public:
   bool isDFP() const { return usesLayout<DFPFloat>(getSemantics());}
 
   bool isSmallestNormalized() const {
-    APFLOAT_DISPATCH_ON_SEMANTICS(isSmallestNormalized());
+    APFLOAT_NO_DFP_DISPATCH_ON_SEMANTICS(isSmallestNormalized());
   }
 
   /// Return the FPClassTest which will return true for the value.
@@ -1636,7 +1650,7 @@ public:
   void dump() const;
 
   bool getExactInverse(APFloat *inv) const {
-    APFLOAT_DISPATCH_ON_SEMANTICS(getExactInverse(inv));
+    APFLOAT_NO_DFP_DISPATCH_ON_SEMANTICS(getExactInverse(inv));
   }
 
   LLVM_READONLY
@@ -1646,7 +1660,7 @@ public:
 
   LLVM_READONLY
   int getExactLog2() const {
-    APFLOAT_DISPATCH_ON_SEMANTICS(getExactLog2());
+    APFLOAT_NO_DFP_DISPATCH_ON_SEMANTICS(getExactLog2());
   }
 
   friend hash_code hash_value(const APFloat &Arg);

--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FloatingPointMode.h"
 #include "llvm/Support/ErrorHandling.h"
+#include <cassert>
 #include <memory>
 
 #define APFLOAT_DISPATCH_ON_SEMANTICS(METHOD_CALL)                             \
@@ -27,6 +28,8 @@
       return U.IEEE.METHOD_CALL;                                               \
     if (usesLayout<DoubleAPFloat>(getSemantics()))                             \
       return U.Double.METHOD_CALL;                                             \
+    if (usesLayout<DFPFloat>(getSemantics()))                                  \
+      return U.DFP.METHOD_CALL;                                                \
     llvm_unreachable("Unexpected semantics");                                  \
   } while (false)
 
@@ -782,16 +785,12 @@ public:
   /// \name Constructors
   /// @{
 
-  DFPFloat(const fltSemantics &) {} // Default construct to +0.0
+  DFPFloat(const fltSemantics &); // Default construct to +0.0
   DFPFloat(const fltSemantics &, integerPart) {
     assert(false && "Not Implemented");
   }
-  DFPFloat(const fltSemantics &, uninitializedTag) {
-    assert(false && "Not Implemented");
-  }
-  DFPFloat(const fltSemantics &, const APInt &) {
-    assert(false && "Not Implemented");
-  }
+  DFPFloat(const fltSemantics &, uninitializedTag);
+  DFPFloat(const fltSemantics &, const APInt &);
   DFPFloat(const DFPFloat &) { assert(false && "Not Implemented"); }
   DFPFloat(DFPFloat &&) { assert(false && "Not Implemented"); }
   ~DFPFloat() {}
@@ -804,54 +803,61 @@ public:
   /// \name Arithmetic
   /// @{
 
-  opStatus add(const DFPFloat &, roundingMode);
-  opStatus subtract(const DFPFloat &, roundingMode);
-  opStatus multiply(const DFPFloat &, roundingMode);
-  opStatus divide(const DFPFloat &, roundingMode);
+  opStatus add(const DFPFloat &, roundingMode)  { assert(false && "Not Implemented"); }
+  opStatus subtract(const DFPFloat &, roundingMode)  { assert(false && "Not Implemented"); }
+  opStatus multiply(const DFPFloat &, roundingMode)  { assert(false && "Not Implemented"); }
+  opStatus divide(const DFPFloat &, roundingMode)  { assert(false && "Not Implemented"); }
 
-  opStatus remainder(const DFPFloat &);
+  opStatus remainder(const DFPFloat &)  { assert(false && "Not Implemented"); }
 
-  opStatus mod(const DFPFloat &);
-  opStatus fusedMultiplyAdd(const DFPFloat &, const DFPFloat &, roundingMode);
-  opStatus roundToIntegral(roundingMode);
-
-  opStatus next(bool nextDown);
+  opStatus mod(const DFPFloat &)  { assert(false && "Not Implemented"); }
+  opStatus fusedMultiplyAdd(const DFPFloat &, const DFPFloat &, roundingMode)  { assert(false && "Not Implemented"); }
+  opStatus roundToIntegral(roundingMode)  { assert(false && "Not Implemented"); }
+  opStatus next(bool nextDown)  { assert(false && "Not Implemented"); }
 
   /// @}
 
   /// \name Sign operations.
   /// @{
 
-  void changeSign();
+  void changeSign()  { assert(false && "Not Implemented"); }
 
   /// @}
 
   /// \name Conversions
   /// @{
 
-  opStatus convert(const fltSemantics &, roundingMode, bool *);
+  opStatus convert(const fltSemantics &, roundingMode, bool *)  { assert(false && "Not Implemented"); }
   opStatus convertToInteger(MutableArrayRef<integerPart>, unsigned int, bool,
-                            roundingMode, bool *) const;
-  opStatus convertFromAPInt(const APInt &, bool, roundingMode);
+                            roundingMode, bool *) const  { assert(false && "Not Implemented"); }
+  opStatus convertFromAPInt(const APInt &, bool, roundingMode)  { assert(false && "Not Implemented"); }
   opStatus convertFromSignExtendedInteger(const integerPart *, unsigned int,
-                                          bool, roundingMode);
+                                          bool, roundingMode)  { assert(false && "Not Implemented"); }
   opStatus convertFromZeroExtendedInteger(const integerPart *, unsigned int,
-                                          bool, roundingMode);
+                                          bool, roundingMode)  { assert(false && "Not Implemented"); };
   Expected<opStatus> convertFromString(StringRef, roundingMode);
+  Expected<opStatus> convertFromStringDFP32(StringRef, roundingMode);
+  Expected<opStatus> convertFromStringDFP64(StringRef, roundingMode);
+  Expected<opStatus> convertFromStringDFP128(StringRef, roundingMode);
+  bool convertFromStringSpecials(StringRef str);
   APInt bitcastToAPInt() const;
-  double convertToDouble() const;
-  float convertToFloat() const;
+  
+  template <const fltSemantics &S>
+  APInt convertDFPToAPInt() const;
+  
+  double convertToDouble() const  { assert(false && "Not Implemented"); }
+  float convertToFloat() const  { assert(false && "Not Implemented"); }
 
   /// @}
 
   bool operator==(const DFPFloat &) const = delete;
 
-  cmpResult compare(const DFPFloat &) const;
+  cmpResult compare(const DFPFloat &) const  { assert(false && "Not Implemented"); }
 
-  bool bitwiseIsEqual(const DFPFloat &) const;
+  bool bitwiseIsEqual(const DFPFloat &) const  { assert(false && "Not Implemented"); }
 
   unsigned int convertToHexString(char *dst, unsigned int hexDigits,
-                                  bool upperCase, roundingMode) const;
+                                  bool upperCase, roundingMode) const { assert(false && "Not Implemented"); }
 
   bool isNegative() const { return sign; }
 
@@ -861,13 +867,13 @@ public:
 
   bool isZero() const { return category == fcZero; }
 
-  bool isDenormal() const;
+  bool isDenormal() const  { assert(false && "Not Implemented"); }
 
   bool isInfinity() const { return category == fcInfinity; }
 
   bool isNaN() const { return category == fcNaN; }
 
-  bool isSignaling() const;
+  bool isSignaling() const { return category == fcNaN && sign; } ;
 
   /// @}
 
@@ -883,23 +889,23 @@ public:
 
   /// Returns true if and only if the number has the smallest possible non-zero
   /// magnitude in the current semantics.
-  bool isSmallest() const;
+  bool isSmallest() const { assert(false && "Not Implemented"); }
 
   /// Returns true if this is the smallest (by magnitude) normalized finite
   /// number in the given semantics.
-  bool isSmallestNormalized() const;
+  bool isSmallestNormalized() const { assert(false && "Not Implemented"); }
 
   /// Returns true if and only if the number has the largest possible finite
   /// magnitude in the current semantics.
-  bool isLargest() const;
+  bool isLargest() const { assert(false && "Not Implemented"); }
 
   /// Returns true if and only if the number is an exact integer.
-  bool isInteger() const;
+  bool isInteger() const { assert(false && "Not Implemented"); }
 
   /// @}
 
-  DFPFloat &operator=(const DFPFloat &);
-  DFPFloat &operator=(DFPFloat &&);
+  DFPFloat &operator=(const DFPFloat &) { assert(false && "Not Implemented"); }
+  DFPFloat &operator=(DFPFloat &&) { assert(false && "Not Implemented"); }
 
   /// Overload to compute a hash code for an DFPFloat value.
   ///
@@ -934,10 +940,16 @@ public:
   /// 1.01E-2              4             1       1.01E-2
   void toString(SmallVectorImpl<char> &Str, unsigned FormatPrecision = 0,
                 unsigned FormatMaxPadding = 3, bool TruncateZero = true) const;
+  void toStringDFP32(SmallVectorImpl<char> &Str, unsigned FormatPrecision = 0,
+                unsigned FormatMaxPadding = 3, bool TruncateZero = true) const;
+  void toStringDFP64(SmallVectorImpl<char> &Str, unsigned FormatPrecision = 0,
+                unsigned FormatMaxPadding = 3, bool TruncateZero = true) const;
+  void toStringDFP128(SmallVectorImpl<char> &Str, unsigned FormatPrecision = 0,
+                unsigned FormatMaxPadding = 3, bool TruncateZero = true) const;
 
   /// If this value has an exact multiplicative inverse, store it in inv and
   /// return true.
-  bool getExactInverse(DFPFloat *inv) const;
+  bool getExactInverse(APFloat *inv) const { assert(false && "Not Implemented"); }
 
   // If this is an exact power of two, return the exponent while ignoring the
   // sign bit. If it's not an exact power of 2, return INT_MIN
@@ -960,23 +972,25 @@ public:
   /// \name Special value setters.
   /// @{
 
-  void makeLargest(bool Neg = false);
-  void makeSmallest(bool Neg = false);
-  void makeNaN(bool SNaN = false, bool Neg = false,
-               const APInt *fill = nullptr);
-  void makeInf(bool Neg = false);
+  void makeLargest(bool Neg = false) { assert(false && "Not Implemented"); }
+  void makeSmallest(bool Neg = false) { assert(false && "Not Implemented"); }
+  void makeNaN(bool SNaN = false, bool Neg = false, const APInt *fill = nullptr);
+  void makeInf(bool Neg = false, bool ExplicitPlus = false);
   void makeZero(bool Neg = false);
+  void makeZeroInternalDFP32(bool Neg = false, int right_of_radix_leading_zero=0);
+  void makeZeroInternalDFP64(bool Neg = false, int right_of_radix_leading_zero=0);
+  void makeZeroInternalDFP128(bool Neg = false, int right_of_radix_leading_zero=0);
   void makeQuiet();
 
   /// Returns the smallest (by magnitude) normalized finite number in the given
   /// semantics.
   ///
   /// \param Negative - True iff the number should be negative
-  void makeSmallestNormalized(bool Negative = false);
+  void makeSmallestNormalized(bool Negative = false) { assert(false && "Not Implemented"); }
 
   /// @}
 
-  cmpResult compareAbsoluteValue(const DFPFloat &) const;
+  cmpResult compareAbsoluteValue(const DFPFloat &) const { assert(false && "Not Implemented"); }
 
 private:
   /// \name Simple Queries
@@ -985,12 +999,31 @@ private:
   integerPart *significandParts();
   const integerPart *significandParts() const;
   unsigned int partCount() const;
+  uint32_t maxFormatDigits() const;
+  uint32_t decimalExponentBias() const;
+  uint32_t decimalMaxExponent() const;
 
   /// @}
+
+  void initialize(const fltSemantics *);
+  void initFromAPInt(const fltSemantics *Sem, const APInt &api);
+  template <const fltSemantics &S> void initFromDFP32APInt(const APInt &api);
+  template <const fltSemantics &S> void initFromDFP64APInt(const APInt &api);
+  template <const fltSemantics &S> void initFromDFP128APInt(const APInt &api);
+
 
   void assign(const DFPFloat &);
   void copySignificand(const DFPFloat &);
   void freeSignificand();
+
+  struct Two64Wrapped {
+     uint64_t w[2];
+  };
+
+  void mul64By64To128(DFPFloat::Two64Wrapped &p, uint64_t cx, uint64_t cy) const;
+  uint64_t addCarryOut(uint64_t &s, uint64_t x, uint64_t y) const;
+  void unpackBID32(uint32_t x, uint32_t &sgn, uint32_t &exp, uint32_t &coeff, bool &isInf, bool &isSNaN, bool &isNaN) const;
+  uint32_t packBID32(uint32_t sgn, int32_t exp, uint64_t coeff, bool negativeExp, bool rounded, roundingMode rounding_mode) const;
 
   /// Note: this must be the first data member.
   /// The semantics that this value obeys.
@@ -1026,6 +1059,7 @@ hash_code hash_value(const DoubleAPFloat &Arg);
 class APFloat : public APFloatBase {
   typedef detail::IEEEFloat IEEEFloat;
   typedef detail::DoubleAPFloat DoubleAPFloat;
+  typedef detail::DFPFloat DFPFloat;
 
   static_assert(std::is_standard_layout<IEEEFloat>::value);
 
@@ -1033,11 +1067,15 @@ class APFloat : public APFloatBase {
     const fltSemantics *semantics;
     IEEEFloat IEEE;
     DoubleAPFloat Double;
+    DFPFloat DFP;
 
     explicit Storage(IEEEFloat F, const fltSemantics &S);
     explicit Storage(DoubleAPFloat F, const fltSemantics &S)
         : Double(std::move(F)) {
       assert(&S == &PPCDoubleDouble());
+    }
+    explicit Storage(DFPFloat F, const fltSemantics &S)
+        : DFP(std::move(F)) {
     }
 
     template <typename... ArgTypes>
@@ -1048,6 +1086,10 @@ class APFloat : public APFloatBase {
       }
       if (usesLayout<DoubleAPFloat>(Semantics)) {
         new (&Double) DoubleAPFloat(Semantics, std::forward<ArgTypes>(Args)...);
+        return;
+      }
+      if (usesLayout<DFPFloat>(Semantics)) {
+        new (&DFP) DFPFloat(Semantics, std::forward<ArgTypes>(Args)...);
         return;
       }
       llvm_unreachable("Unexpected semantics");
@@ -1062,6 +1104,10 @@ class APFloat : public APFloatBase {
         Double.~DoubleAPFloat();
         return;
       }
+      if (usesLayout<DFPFloat>(*semantics)) {
+        DFP.~DFPFloat();
+        return;
+      }
       llvm_unreachable("Unexpected semantics");
     }
 
@@ -1072,6 +1118,10 @@ class APFloat : public APFloatBase {
       }
       if (usesLayout<DoubleAPFloat>(*RHS.semantics)) {
         new (this) DoubleAPFloat(RHS.Double);
+        return;
+      }
+      if (usesLayout<DFPFloat>(*RHS.semantics)) {
+        new (this) DFPFloat(RHS.DFP);
         return;
       }
       llvm_unreachable("Unexpected semantics");
@@ -1086,6 +1136,10 @@ class APFloat : public APFloatBase {
         new (this) DoubleAPFloat(std::move(RHS.Double));
         return;
       }
+      if (usesLayout<DFPFloat>(*RHS.semantics)) {
+        new (this) DFPFloat(std::move(RHS.DFP));
+        return;
+      }
       llvm_unreachable("Unexpected semantics");
     }
 
@@ -1095,7 +1149,10 @@ class APFloat : public APFloatBase {
         IEEE = RHS.IEEE;
       } else if (usesLayout<DoubleAPFloat>(*semantics) &&
                  usesLayout<DoubleAPFloat>(*RHS.semantics)) {
-        Double = RHS.Double;
+        Double = RHS.Double; 
+      } else if (usesLayout<DFPFloat>(*semantics) &&
+                 usesLayout<DFPFloat>(*RHS.semantics)) {
+        DFP = RHS.DFP; 
       } else if (this != &RHS) {
         this->~Storage();
         new (this) Storage(RHS);
@@ -1110,6 +1167,9 @@ class APFloat : public APFloatBase {
       } else if (usesLayout<DoubleAPFloat>(*semantics) &&
                  usesLayout<DoubleAPFloat>(*RHS.semantics)) {
         Double = std::move(RHS.Double);
+      } else if (usesLayout<DFPFloat>(*semantics) &&
+                 usesLayout<DFPFloat>(*RHS.semantics)) {
+        DFP = std::move(RHS.DFP);
       } else if (this != &RHS) {
         this->~Storage();
         new (this) Storage(std::move(RHS));
@@ -1120,11 +1180,23 @@ class APFloat : public APFloatBase {
 
   template <typename T> static bool usesLayout(const fltSemantics &Semantics) {
     static_assert(std::is_same<T, IEEEFloat>::value ||
-                  std::is_same<T, DoubleAPFloat>::value);
+                  std::is_same<T, DoubleAPFloat>::value ||
+                  std::is_same<T, DFPFloat>::value);
     if (std::is_same<T, DoubleAPFloat>::value) {
       return &Semantics == &PPCDoubleDouble();
+    } if (std::is_same<T, IEEEFloat>::value) {
+      return &Semantics == &IEEEhalf() ||
+             &Semantics == &BFloat() || 
+             &Semantics == &IEEEsingle() ||
+             &Semantics == &IEEEdouble() ||
+             &Semantics == &IEEEquad();
+ 
+    } else if (std::is_same<T, DFPFloat>::value) {
+      return &Semantics == &DFP32() ||
+             &Semantics == &DFP64() ||
+             &Semantics == &DFP128();
     }
-    return &Semantics != &PPCDoubleDouble();
+     llvm_unreachable("Unexpected semantics");
   }
 
   IEEEFloat &getIEEE() {
@@ -1557,6 +1629,7 @@ public:
   bool isLargest() const { APFLOAT_DISPATCH_ON_SEMANTICS(isLargest()); }
   bool isInteger() const { APFLOAT_DISPATCH_ON_SEMANTICS(isInteger()); }
   bool isIEEE() const { return usesLayout<IEEEFloat>(getSemantics()); }
+  bool isDFP() const { return usesLayout<DFPFloat>(getSemantics());}
 
   bool isSmallestNormalized() const {
     APFLOAT_DISPATCH_ON_SEMANTICS(isSmallestNormalized());

--- a/llvm/include/llvm/ADT/FloatingPointMode.h
+++ b/llvm/include/llvm/ADT/FloatingPointMode.h
@@ -47,14 +47,6 @@ enum class RoundingMode : int8_t {
   Invalid = -1    ///< Denotes invalid value.
 };
 
-enum class DFPRoundingMode : int8_t {
-  Downward          = 0,
-  ToNearest         = 1,
-  ToNearestFromZero = 2,
-  TowardZero        = 3,
-  Upward            = 4,
-};
-
 /// Returns text representation of the given rounding mode.
 inline StringRef spell(RoundingMode RM) {
   switch (RM) {

--- a/llvm/include/llvm/ADT/FloatingPointMode.h
+++ b/llvm/include/llvm/ADT/FloatingPointMode.h
@@ -47,6 +47,14 @@ enum class RoundingMode : int8_t {
   Invalid = -1    ///< Denotes invalid value.
 };
 
+enum class DFPRoundingMode : int8_t {
+  Downward          = 0,
+  ToNearest         = 1,
+  ToNearestFromZero = 2,
+  TowardZero        = 3,
+  Upward            = 4,
+};
+
 /// Returns text representation of the given rounding mode.
 inline StringRef spell(RoundingMode RM) {
   switch (RM) {

--- a/llvm/include/llvm/IR/DataLayout.h
+++ b/llvm/include/llvm/IR/DataLayout.h
@@ -715,11 +715,11 @@ inline TypeSize DataLayout::getTypeSizeInBits(Type *Ty) const {
     Type *LayoutTy = cast<TargetExtType>(Ty)->getLayoutType();
     return getTypeSizeInBits(LayoutTy);
   }
-  case Type::Decimal32TyID:
+  case Type::DecimalFloat32TyID:
     return TypeSize::Fixed(32);
-  case Type::Decimal64TyID:
+  case Type::DecimalFloat64TyID:
     return TypeSize::Fixed(64);
-  case Type::Decimal128TyID:
+  case Type::DecimalFloat128TyID:
     return TypeSize::Fixed(128);
   default:
     llvm_unreachable("DataLayout::getTypeSizeInBits(): Unsupported type");

--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -547,19 +547,13 @@ public:
   }
 
   /// Fetch the type representing a 32-bit decimal floating point value.
-  Type *getDecimal32Ty() {
-    return Type::getDecimal32Ty(Context);
-  }
+  Type *getDecimalFloat32Ty() { return Type::getDecimalFloat32Ty(Context); }
 
   /// Fetch the type representing a 64-bit decimal floating point value.
-  Type *getDecimal64Ty() {
-    return Type::getDecimal64Ty(Context);
-  }
+  Type *getDecimalFloat64Ty() { return Type::getDecimalFloat64Ty(Context); }
 
   /// Fetch the type representing a 128-bit decimal floating point value.
-  Type *getDecimal128Ty() {
-    return Type::getDecimal128Ty(Context);
-  }
+  Type *getDecimalFloat128Ty() { return Type::getDecimalFloat128Ty(Context); }
 
   /// Fetch the type representing void.
   Type *getVoidTy() {

--- a/llvm/include/llvm/IR/Type.h
+++ b/llvm/include/llvm/IR/Type.h
@@ -68,9 +68,9 @@ public:
     TokenTyID,     ///< Tokens
 
     // Decimal floating-point types.
-    Decimal32TyID, ///< 32-bit decimal floating point type
-    Decimal64TyID, ///< 64-bit decimal floating point type
-    Decimal128TyID, ///< 128-bit decimal floating point type
+    DecimalFloat32TyID,  ///< 32-bit decimal floating point type
+    DecimalFloat64TyID,  ///< 64-bit decimal floating point type
+    DecimalFloat128TyID, ///< 128-bit decimal floating point type
 
     // Derived types... see DerivedTypes.h file.
     IntegerTyID,        ///< Arbitrary bit width integers
@@ -171,18 +171,21 @@ public:
   bool isPPC_FP128Ty() const { return getTypeID() == PPC_FP128TyID; }
 
   /// Return true if this is 'decimal32'.
-  bool isDecimal32Ty() const { return getTypeID() == Decimal32TyID; }
+  bool isDecimalFloat32Ty() const { return getTypeID() == DecimalFloat32TyID; }
 
   /// Return true if this is 'decimal64'.
-  bool isDecimal64Ty() const { return getTypeID() == Decimal64TyID; }
+  bool isDecimalFloat64Ty() const { return getTypeID() == DecimalFloat64TyID; }
 
   /// Return true if this is 'decimal128'.
-  bool isDecimal128Ty() const { return getTypeID() == Decimal128TyID; }
+  bool isDecimalFloat128Ty() const {
+    return getTypeID() == DecimalFloat128TyID;
+  }
 
   /// Return true if this is a decimal floating point.
   bool isDecimalFloatingPointTy() const {
-    return getTypeID() == Decimal32TyID || getTypeID() == Decimal64TyID ||
-           getTypeID() == Decimal128TyID;
+    return getTypeID() == DecimalFloat32TyID ||
+           getTypeID() == DecimalFloat64TyID ||
+           getTypeID() == DecimalFloat128TyID;
   }
 
   /// Return true if this is a well-behaved IEEE-like type, which has a IEEE
@@ -488,9 +491,9 @@ public:
   static IntegerType *getInt32Ty(LLVMContext &C);
   static IntegerType *getInt64Ty(LLVMContext &C);
   static IntegerType *getInt128Ty(LLVMContext &C);
-  static Type *getDecimal32Ty(LLVMContext &C);
-  static Type *getDecimal64Ty(LLVMContext &C);
-  static Type *getDecimal128Ty(LLVMContext &C);
+  static Type *getDecimalFloat32Ty(LLVMContext &C);
+  static Type *getDecimalFloat64Ty(LLVMContext &C);
+  static Type *getDecimalFloat128Ty(LLVMContext &C);
   template <typename ScalarTy> static Type *getScalarTy(LLVMContext &C) {
     int noOfBits = sizeof(ScalarTy) * CHAR_BIT;
     if (std::is_integral<ScalarTy>::value) {

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -826,9 +826,9 @@ lltok::Kind LLLexer::LexIdentifier() {
   TYPEKEYWORD("x86_amx",   Type::getX86_AMXTy(Context));
   TYPEKEYWORD("token",     Type::getTokenTy(Context));
   TYPEKEYWORD("ptr",       PointerType::getUnqual(Context));
-  TYPEKEYWORD("decimal32", Type::getDecimal32Ty(Context));
-  TYPEKEYWORD("decimal64", Type::getDecimal64Ty(Context));
-  TYPEKEYWORD("decimal128", Type::getDecimal128Ty(Context));
+  TYPEKEYWORD("decimal32", Type::getDecimalFloat32Ty(Context));
+  TYPEKEYWORD("decimal64", Type::getDecimalFloat64Ty(Context));
+  TYPEKEYWORD("decimal128", Type::getDecimalFloat128Ty(Context));
 
 #undef TYPEKEYWORD
 

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -2509,13 +2509,13 @@ Error BitcodeReader::parseTypeTableBody() {
       break;
     }
     case bitc::TYPE_CODE_DECIMAL32: // 32-bit DFP
-      ResultTy = Type::getDecimal32Ty(Context);
+      ResultTy = Type::getDecimalFloat32Ty(Context);
       break;
     case bitc::TYPE_CODE_DECIMAL64: // 64-bit DFP
-      ResultTy = Type::getDecimal64Ty(Context);
+      ResultTy = Type::getDecimalFloat64Ty(Context);
       break;
     case bitc::TYPE_CODE_DECIMAL128: // 128-bit DFP
-      ResultTy = Type::getDecimal128Ty(Context);
+      ResultTy = Type::getDecimalFloat128Ty(Context);
       break;
     case bitc::TYPE_CODE_ARRAY:     // ARRAY: [numelts, eltty]
       if (Record.size() < 2)

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -976,9 +976,15 @@ void ModuleBitcodeWriter::writeTypeTable() {
     case Type::X86_FP80TyID:  Code = bitc::TYPE_CODE_X86_FP80;  break;
     case Type::FP128TyID:     Code = bitc::TYPE_CODE_FP128;     break;
     case Type::PPC_FP128TyID: Code = bitc::TYPE_CODE_PPC_FP128; break;
-    case Type::Decimal32TyID: Code = bitc::TYPE_CODE_DECIMAL32; break;
-    case Type::Decimal64TyID: Code = bitc::TYPE_CODE_DECIMAL64; break;
-    case Type::Decimal128TyID: Code = bitc::TYPE_CODE_DECIMAL128; break;
+    case Type::DecimalFloat32TyID:
+      Code = bitc::TYPE_CODE_DECIMAL32;
+      break;
+    case Type::DecimalFloat64TyID:
+      Code = bitc::TYPE_CODE_DECIMAL64;
+      break;
+    case Type::DecimalFloat128TyID:
+      Code = bitc::TYPE_CODE_DECIMAL128;
+      break;
     case Type::LabelTyID:     Code = bitc::TYPE_CODE_LABEL;     break;
     case Type::MetadataTyID:  Code = bitc::TYPE_CODE_METADATA;  break;
     case Type::X86_MMXTyID:   Code = bitc::TYPE_CODE_X86_MMX;   break;

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -561,9 +561,15 @@ void TypePrinting::print(Type *Ty, raw_ostream &OS) {
   case Type::IntegerTyID:
     OS << 'i' << cast<IntegerType>(Ty)->getBitWidth();
     return;
-  case Type::Decimal32TyID:  OS << "decimal32"; return;
-  case Type::Decimal64TyID:  OS << "decimal64"; return;
-  case Type::Decimal128TyID: OS << "decimal128"; return;
+  case Type::DecimalFloat32TyID:
+    OS << "decimal32";
+    return;
+  case Type::DecimalFloat64TyID:
+    OS << "decimal64";
+    return;
+  case Type::DecimalFloat128TyID:
+    OS << "decimal128";
+    return;
 
   case Type::FunctionTyID: {
     FunctionType *FTy = cast<FunctionType>(Ty);

--- a/llvm/lib/IR/Core.cpp
+++ b/llvm/lib/IR/Core.cpp
@@ -563,12 +563,12 @@ LLVMTypeKind LLVMGetTypeKind(LLVMTypeRef Ty) {
     return LLVMFP128TypeKind;
   case Type::PPC_FP128TyID:
     return LLVMPPC_FP128TypeKind;
-  case Type::Decimal32TyID:
-    return LLVMDecimal32TypeKind;
-  case Type::Decimal64TyID:
-    return LLVMDecimal64TypeKind;
-  case Type::Decimal128TyID:
-    return LLVMDecimal128TypeKind;
+  case Type::DecimalFloat32TyID:
+    return LLVMDecimalFloat32TypeKind;
+  case Type::DecimalFloat64TyID:
+    return LLVMDecimalFloat64TypeKind;
+  case Type::DecimalFloat128TyID:
+    return LLVMDecimalFloat128TypeKind;
   case Type::LabelTyID:
     return LLVMLabelTypeKind;
   case Type::MetadataTyID:

--- a/llvm/lib/IR/LLVMContextImpl.cpp
+++ b/llvm/lib/IR/LLVMContextImpl.cpp
@@ -43,8 +43,9 @@ LLVMContextImpl::LLVMContextImpl(LLVMContext &C)
       PPC_FP128Ty(C, Type::PPC_FP128TyID), X86_MMXTy(C, Type::X86_MMXTyID),
       X86_AMXTy(C, Type::X86_AMXTyID), Int1Ty(C, 1), Int8Ty(C, 8),
       Int16Ty(C, 16), Int32Ty(C, 32), Int64Ty(C, 64), Int128Ty(C, 128),
-      Decimal32Ty(C, Type::Decimal32TyID), Decimal64Ty(C, Type::Decimal64TyID),
-      Decimal128Ty(C, Type::Decimal128TyID) {}
+      DecimalFloat32Ty(C, Type::DecimalFloat32TyID),
+      DecimalFloat64Ty(C, Type::DecimalFloat64TyID),
+      DecimalFloat128Ty(C, Type::DecimalFloat128TyID) {}
 
 LLVMContextImpl::~LLVMContextImpl() {
   // NOTE: We need to delete the contents of OwnedModules, but Module's dtor

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -1524,7 +1524,7 @@ public:
       TokenTy;
   Type X86_FP80Ty, FP128Ty, PPC_FP128Ty, X86_MMXTy, X86_AMXTy;
   IntegerType Int1Ty, Int8Ty, Int16Ty, Int32Ty, Int64Ty, Int128Ty;
-  Type Decimal32Ty, Decimal64Ty, Decimal128Ty;
+  Type DecimalFloat32Ty, DecimalFloat64Ty, DecimalFloat128Ty;
 
   std::unique_ptr<ConstantTokenNone> TheNoneToken;
 

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -48,9 +48,12 @@ Type *Type::getPrimitiveType(LLVMContext &C, TypeID IDNumber) {
   case X86_MMXTyID   : return getX86_MMXTy(C);
   case X86_AMXTyID   : return getX86_AMXTy(C);
   case TokenTyID     : return getTokenTy(C);
-  case Decimal32TyID :  return getDecimal32Ty(C);
-  case Decimal64TyID :  return getDecimal64Ty(C);
-  case Decimal128TyID: return getDecimal128Ty(C);
+  case DecimalFloat32TyID:
+    return getDecimalFloat32Ty(C);
+  case DecimalFloat64TyID:
+    return getDecimalFloat64Ty(C);
+  case DecimalFloat128TyID:
+    return getDecimalFloat128Ty(C);
   default:
     return nullptr;
   }
@@ -182,9 +185,12 @@ TypeSize Type::getPrimitiveSizeInBits() const {
   case Type::X86_FP80TyID: return TypeSize::Fixed(80);
   case Type::FP128TyID: return TypeSize::Fixed(128);
   case Type::PPC_FP128TyID: return TypeSize::Fixed(128);
-  case Decimal32TyID: return TypeSize::Fixed(32);
-  case Decimal64TyID: return TypeSize::Fixed(64);
-  case Decimal128TyID: return TypeSize::Fixed(128);
+  case DecimalFloat32TyID:
+    return TypeSize::Fixed(32);
+  case DecimalFloat64TyID:
+    return TypeSize::Fixed(64);
+  case DecimalFloat128TyID:
+    return TypeSize::Fixed(128);
   case Type::X86_MMXTyID: return TypeSize::Fixed(64);
   case Type::X86_AMXTyID: return TypeSize::Fixed(8192);
   case Type::IntegerTyID:
@@ -226,9 +232,12 @@ int Type::getDFPPrecisionInDigits() const {
   assert(isDecimalFloatingPointTy() && "Not a decimal floating point type!");
   // Precision values per the "Decimal interchange format parameters" table of
   /// C23 annex H.2.1, "Interchange floating types".
-  if (getTypeID() == Decimal32TyID) return 7;
-  if (getTypeID() == Decimal64TyID) return 16;
-  if (getTypeID() == Decimal128TyID) return 34;
+  if (getTypeID() == DecimalFloat32TyID)
+    return 7;
+  if (getTypeID() == DecimalFloat64TyID)
+    return 16;
+  if (getTypeID() == DecimalFloat128TyID)
+    return 34;
   report_fatal_error("unknown decimal floating point type");
 }
 
@@ -263,9 +272,15 @@ Type *Type::getPPC_FP128Ty(LLVMContext &C) { return &C.pImpl->PPC_FP128Ty; }
 Type *Type::getX86_MMXTy(LLVMContext &C) { return &C.pImpl->X86_MMXTy; }
 Type *Type::getX86_AMXTy(LLVMContext &C) { return &C.pImpl->X86_AMXTy; }
 
-Type *Type::getDecimal32Ty(LLVMContext &C) { return &C.pImpl->Decimal32Ty; }
-Type *Type::getDecimal64Ty(LLVMContext &C) { return &C.pImpl->Decimal64Ty; }
-Type *Type::getDecimal128Ty(LLVMContext &C) { return &C.pImpl->Decimal128Ty; }
+Type *Type::getDecimalFloat32Ty(LLVMContext &C) {
+  return &C.pImpl->DecimalFloat32Ty;
+}
+Type *Type::getDecimalFloat64Ty(LLVMContext &C) {
+  return &C.pImpl->DecimalFloat64Ty;
+}
+Type *Type::getDecimalFloat128Ty(LLVMContext &C) {
+  return &C.pImpl->DecimalFloat128Ty;
+}
 
 IntegerType *Type::getInt1Ty(LLVMContext &C) { return &C.pImpl->Int1Ty; }
 IntegerType *Type::getInt8Ty(LLVMContext &C) { return &C.pImpl->Int8Ty; }

--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -151,6 +151,7 @@ static constexpr fltSemantics semDFP64 = {385, -382, 53, 64,
 // BID significand can be up to 113 bits but DPD can be up to 110
 static constexpr fltSemantics semDFP128 = {6145, -6142, 113, 128,
                                            APFloatBase::BaseTen};
+// clang-format on
 
 /* The IBM double-double semantics. Such a number consists of a pair of IEEE
    64-bit doubles (Hi, Lo), where |Hi| > |Lo|, and if normal,
@@ -4550,6 +4551,13 @@ void IEEEFloat::toString(SmallVectorImpl<char> &Str, unsigned FormatPrecision,
 
   for (; I != NDigits; ++I)
     Str.push_back(buffer[NDigits-I-1]);
+}
+
+void DFPFloat::changeSign() {
+   if(isZero())
+    return;
+
+  sign = !sign;
 }
 
 uint32_t DFPFloat::maxFormatDigits() const {

--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -34,6 +34,8 @@
       return U.IEEE.METHOD_CALL;                                               \
     if (usesLayout<DoubleAPFloat>(getSemantics()))                             \
       return U.Double.METHOD_CALL;                                             \
+    if (usesLayout<DFPFloat>(getSemantics()))                                  \
+      return U.DFP.METHOD_CALL;                                                \
     llvm_unreachable("Unexpected semantics");                                  \
   } while (false)
 
@@ -167,10 +169,13 @@ static constexpr fltSemantics semFloatTF32 = {127, -126, 11, 19};
 static constexpr fltSemantics semX87DoubleExtended = {16383, -16382, 64, 80};
 static constexpr fltSemantics semBogus = {0, 0, 0, 0};
 // Values come from  "Decimal interchange format parameters" table in C23 H.2.1
-static constexpr fltSemantics semDFP32 = {97, -94, 7, 32, APFloatBase::BaseTen};
-static constexpr fltSemantics semDFP64 = {385, -382, 16, 64,
+// BID significand can be up to 23 bits but DPD can be up to 20
+static constexpr fltSemantics semDFP32 = {97, -94, 23, 32, APFloatBase::BaseTen};
+// BID significand can be up to 53 bits but DPD can be up to 50
+static constexpr fltSemantics semDFP64 = {385, -382, 53, 64,
                                           APFloatBase::BaseTen};
-static constexpr fltSemantics semDFP128 = {6145, -6142, 34, 128,
+// BID significand can be up to 113 bits but DPD can be up to 110
+static constexpr fltSemantics semDFP128 = {6145, -6142, 113, 128,
                                            APFloatBase::BaseTen};
 
 /* The IBM double-double semantics. Such a number consists of a pair of IEEE
@@ -4090,7 +4095,267 @@ namespace {
     exp += FirstSignificant;
     buffer.erase(&buffer[0], &buffer[FirstSignificant]);
   }
+
+static constexpr char bid_midi_tbl[1000][4] = { 
+  "000", "001", "002", "003", "004", "005", "006", "007", "008", "009",
+  "010", "011", "012", "013", "014", "015", "016", "017", "018", "019",
+  "020", "021", "022", "023", "024", "025", "026", "027", "028", "029",
+  "030", "031", "032", "033", "034", "035", "036", "037", "038", "039",
+  "040", "041", "042", "043", "044", "045", "046", "047", "048", "049",
+  "050", "051", "052", "053", "054", "055", "056", "057", "058", "059",
+  "060", "061", "062", "063", "064", "065", "066", "067", "068", "069",
+  "070", "071", "072", "073", "074", "075", "076", "077", "078", "079",
+  "080", "081", "082", "083", "084", "085", "086", "087", "088", "089",
+  "090", "091", "092", "093", "094", "095", "096", "097", "098", "099",
+  "100", "101", "102", "103", "104", "105", "106", "107", "108", "109",
+  "110", "111", "112", "113", "114", "115", "116", "117", "118", "119",
+  "120", "121", "122", "123", "124", "125", "126", "127", "128", "129",
+  "130", "131", "132", "133", "134", "135", "136", "137", "138", "139",
+  "140", "141", "142", "143", "144", "145", "146", "147", "148", "149",
+  "150", "151", "152", "153", "154", "155", "156", "157", "158", "159",
+  "160", "161", "162", "163", "164", "165", "166", "167", "168", "169",
+  "170", "171", "172", "173", "174", "175", "176", "177", "178", "179",
+  "180", "181", "182", "183", "184", "185", "186", "187", "188", "189",
+  "190", "191", "192", "193", "194", "195", "196", "197", "198", "199",
+  "200", "201", "202", "203", "204", "205", "206", "207", "208", "209",
+  "210", "211", "212", "213", "214", "215", "216", "217", "218", "219",
+  "220", "221", "222", "223", "224", "225", "226", "227", "228", "229",
+  "230", "231", "232", "233", "234", "235", "236", "237", "238", "239",
+  "240", "241", "242", "243", "244", "245", "246", "247", "248", "249",
+  "250", "251", "252", "253", "254", "255", "256", "257", "258", "259",
+  "260", "261", "262", "263", "264", "265", "266", "267", "268", "269",
+  "270", "271", "272", "273", "274", "275", "276", "277", "278", "279",
+  "280", "281", "282", "283", "284", "285", "286", "287", "288", "289",
+  "290", "291", "292", "293", "294", "295", "296", "297", "298", "299",
+  "300", "301", "302", "303", "304", "305", "306", "307", "308", "309",
+  "310", "311", "312", "313", "314", "315", "316", "317", "318", "319",
+  "320", "321", "322", "323", "324", "325", "326", "327", "328", "329",
+  "330", "331", "332", "333", "334", "335", "336", "337", "338", "339",
+  "340", "341", "342", "343", "344", "345", "346", "347", "348", "349",
+  "350", "351", "352", "353", "354", "355", "356", "357", "358", "359",
+  "360", "361", "362", "363", "364", "365", "366", "367", "368", "369",
+  "370", "371", "372", "373", "374", "375", "376", "377", "378", "379",
+  "380", "381", "382", "383", "384", "385", "386", "387", "388", "389",
+  "390", "391", "392", "393", "394", "395", "396", "397", "398", "399",
+  "400", "401", "402", "403", "404", "405", "406", "407", "408", "409",
+  "410", "411", "412", "413", "414", "415", "416", "417", "418", "419",
+  "420", "421", "422", "423", "424", "425", "426", "427", "428", "429",
+  "430", "431", "432", "433", "434", "435", "436", "437", "438", "439",
+  "440", "441", "442", "443", "444", "445", "446", "447", "448", "449",
+  "450", "451", "452", "453", "454", "455", "456", "457", "458", "459",
+  "460", "461", "462", "463", "464", "465", "466", "467", "468", "469",
+  "470", "471", "472", "473", "474", "475", "476", "477", "478", "479",
+  "480", "481", "482", "483", "484", "485", "486", "487", "488", "489",
+  "490", "491", "492", "493", "494", "495", "496", "497", "498", "499",
+  "500", "501", "502", "503", "504", "505", "506", "507", "508", "509",
+  "510", "511", "512", "513", "514", "515", "516", "517", "518", "519",
+  "520", "521", "522", "523", "524", "525", "526", "527", "528", "529",
+  "530", "531", "532", "533", "534", "535", "536", "537", "538", "539",
+  "540", "541", "542", "543", "544", "545", "546", "547", "548", "549",
+  "550", "551", "552", "553", "554", "555", "556", "557", "558", "559",
+  "560", "561", "562", "563", "564", "565", "566", "567", "568", "569",
+  "570", "571", "572", "573", "574", "575", "576", "577", "578", "579",
+  "580", "581", "582", "583", "584", "585", "586", "587", "588", "589",
+  "590", "591", "592", "593", "594", "595", "596", "597", "598", "599",
+  "600", "601", "602", "603", "604", "605", "606", "607", "608", "609",
+  "610", "611", "612", "613", "614", "615", "616", "617", "618", "619",
+  "620", "621", "622", "623", "624", "625", "626", "627", "628", "629",
+  "630", "631", "632", "633", "634", "635", "636", "637", "638", "639",
+  "640", "641", "642", "643", "644", "645", "646", "647", "648", "649",
+  "650", "651", "652", "653", "654", "655", "656", "657", "658", "659",
+  "660", "661", "662", "663", "664", "665", "666", "667", "668", "669",
+  "670", "671", "672", "673", "674", "675", "676", "677", "678", "679",
+  "680", "681", "682", "683", "684", "685", "686", "687", "688", "689",
+  "690", "691", "692", "693", "694", "695", "696", "697", "698", "699",
+  "700", "701", "702", "703", "704", "705", "706", "707", "708", "709",
+  "710", "711", "712", "713", "714", "715", "716", "717", "718", "719",
+  "720", "721", "722", "723", "724", "725", "726", "727", "728", "729",
+  "730", "731", "732", "733", "734", "735", "736", "737", "738", "739",
+  "740", "741", "742", "743", "744", "745", "746", "747", "748", "749",
+  "750", "751", "752", "753", "754", "755", "756", "757", "758", "759",
+  "760", "761", "762", "763", "764", "765", "766", "767", "768", "769",
+  "770", "771", "772", "773", "774", "775", "776", "777", "778", "779",
+  "780", "781", "782", "783", "784", "785", "786", "787", "788", "789",
+  "790", "791", "792", "793", "794", "795", "796", "797", "798", "799",
+  "800", "801", "802", "803", "804", "805", "806", "807", "808", "809",
+  "810", "811", "812", "813", "814", "815", "816", "817", "818", "819",
+  "820", "821", "822", "823", "824", "825", "826", "827", "828", "829",
+  "830", "831", "832", "833", "834", "835", "836", "837", "838", "839",
+  "840", "841", "842", "843", "844", "845", "846", "847", "848", "849",
+  "850", "851", "852", "853", "854", "855", "856", "857", "858", "859",
+  "860", "861", "862", "863", "864", "865", "866", "867", "868", "869",
+  "870", "871", "872", "873", "874", "875", "876", "877", "878", "879",
+  "880", "881", "882", "883", "884", "885", "886", "887", "888", "889",
+  "890", "891", "892", "893", "894", "895", "896", "897", "898", "899",
+  "900", "901", "902", "903", "904", "905", "906", "907", "908", "909",
+  "910", "911", "912", "913", "914", "915", "916", "917", "918", "919",
+  "920", "921", "922", "923", "924", "925", "926", "927", "928", "929",
+  "930", "931", "932", "933", "934", "935", "936", "937", "938", "939",
+  "940", "941", "942", "943", "944", "945", "946", "947", "948", "949",
+  "950", "951", "952", "953", "954", "955", "956", "957", "958", "959",
+  "960", "961", "962", "963", "964", "965", "966", "967", "968", "969",
+  "970", "971", "972", "973", "974", "975", "976", "977", "978", "979",
+  "980", "981", "982", "983", "984", "985", "986", "987", "988", "989",
+  "990", "991", "992", "993", "994", "995", "996", "997", "998", "999"
+};
+
+static constexpr uint64_t bid_round_const_table[][19] = {
+  {     // RN
+   0ull,        // 0 extra digits
+   5ull,        // 1 extra digits
+   50ull,       // 2 extra digits
+   500ull,      // 3 extra digits
+   5000ull,     // 4 extra digits
+   50000ull,    // 5 extra digits
+   500000ull,   // 6 extra digits
+   5000000ull,  // 7 extra digits
+   50000000ull, // 8 extra digits
+   500000000ull,        // 9 extra digits
+   5000000000ull,       // 10 extra digits
+   50000000000ull,      // 11 extra digits
+   500000000000ull,     // 12 extra digits
+   5000000000000ull,    // 13 extra digits
+   50000000000000ull,   // 14 extra digits
+   500000000000000ull,  // 15 extra digits
+   5000000000000000ull, // 16 extra digits
+   50000000000000000ull,        // 17 extra digits
+   500000000000000000ull        // 18 extra digits
+   }
+  ,
+{     // RD
+   0ull,        // 0 extra digits
+   0ull,        // 1 extra digits
+   0ull,        // 2 extra digits
+   00ull,       // 3 extra digits
+   000ull,      // 4 extra digits
+   0000ull,     // 5 extra digits
+   00000ull,    // 6 extra digits
+   000000ull,   // 7 extra digits
+   0000000ull,  // 8 extra digits
+   00000000ull, // 9 extra digits
+   000000000ull,        // 10 extra digits
+   0000000000ull,       // 11 extra digits
+   00000000000ull,      // 12 extra digits
+   000000000000ull,     // 13 extra digits
+   0000000000000ull,    // 14 extra digits
+   00000000000000ull,   // 15 extra digits
+   000000000000000ull,  // 16 extra digits
+   0000000000000000ull, // 17 extra digits
+   00000000000000000ull // 18 extra digits
+   }
+  ,
+{     // round to Inf
+   0ull,        // 0 extra digits
+   9ull,        // 1 extra digits
+   99ull,       // 2 extra digits
+   999ull,      // 3 extra digits
+   9999ull,     // 4 extra digits
+   99999ull,    // 5 extra digits
+   999999ull,   // 6 extra digits
+   9999999ull,  // 7 extra digits
+   99999999ull, // 8 extra digits
+   999999999ull,        // 9 extra digits
+   9999999999ull,       // 10 extra digits
+   99999999999ull,      // 11 extra digits
+   999999999999ull,     // 12 extra digits
+   9999999999999ull,    // 13 extra digits
+   99999999999999ull,   // 14 extra digits
+   999999999999999ull,  // 15 extra digits
+   9999999999999999ull, // 16 extra digits
+   99999999999999999ull,        // 17 extra digits
+   999999999999999999ull        // 18 extra digits
+   }
+  ,
+{     // RZ
+   0ull,        // 0 extra digits
+   0ull,        // 1 extra digits
+   0ull,        // 2 extra digits
+   00ull,       // 3 extra digits
+   000ull,      // 4 extra digits
+   0000ull,     // 5 extra digits
+   00000ull,    // 6 extra digits
+   000000ull,   // 7 extra digits
+   0000000ull,  // 8 extra digits
+   00000000ull, // 9 extra digits
+   000000000ull,        // 10 extra digits
+   0000000000ull,       // 11 extra digits
+   00000000000ull,      // 12 extra digits
+   000000000000ull,     // 13 extra digits
+   0000000000000ull,    // 14 extra digits
+   00000000000000ull,   // 15 extra digits
+   000000000000000ull,  // 16 extra digits
+   0000000000000000ull, // 17 extra digits
+   00000000000000000ull // 18 extra digits
+   }
+  ,
+{     // round ties away from 0
+   0ull,        // 0 extra digits
+   5ull,        // 1 extra digits
+   50ull,       // 2 extra digits
+   500ull,      // 3 extra digits
+   5000ull,     // 4 extra digits
+   50000ull,    // 5 extra digits
+   500000ull,   // 6 extra digits
+   5000000ull,  // 7 extra digits
+   50000000ull, // 8 extra digits
+   500000000ull,        // 9 extra digits
+   5000000000ull,       // 10 extra digits
+   50000000000ull,      // 11 extra digits
+   500000000000ull,     // 12 extra digits
+   5000000000000ull,    // 13 extra digits
+   50000000000000ull,   // 14 extra digits
+   500000000000000ull,  // 15 extra digits
+   5000000000000000ull, // 16 extra digits
+   50000000000000000ull,        // 17 extra digits
+   500000000000000000ull        // 18 extra digits
+   }
+  ,
+};
+
+static constexpr int bid_short_recip_scale[] = {
+  1,
+  65 - 64,
+  69 - 64,
+  71 - 64,
+  75 - 64,
+  78 - 64,
+  81 - 64,
+  85 - 64,
+  88 - 64,
+  91 - 64,
+  95 - 64, 
+  98 - 64,
+  101 - 64,     
+  105 - 64,     
+  108 - 64,     
+  111 - 64,     
+  115 - 64,     //114 - 64
+  118 - 64
+}; 
+
+static constexpr uint64_t bid_reciprocals10_64[] = {
+  1ull, // dummy value for 0 extra digits
+  0x3333333333333334ull,        // 1 extra digit
+  0x51eb851eb851eb86ull,
+  0x20c49ba5e353f7cfull,
+  0x346dc5d63886594bull,
+  0x29f16b11c6d1e109ull,
+  0x218def416bdb1a6eull,
+  0x35afe535795e90b0ull,
+  0x2af31dc4611873c0ull,
+  0x225c17d04dad2966ull,
+  0x36f9bfb3af7b7570ull,
+  0x2bfaffc2f2c92ac0ull,
+  0x232f33025bd42233ull,
+  0x384b84d092ed0385ull,
+  0x2d09370d42573604ull,
+  0x24075f3dceac2b37ull,
+  0x39a5652fb1137857ull,
+  0x2e1dea8c8da92d13ull
+};
 } // namespace
+
+
 
 void IEEEFloat::toString(SmallVectorImpl<char> &Str, unsigned FormatPrecision,
                          unsigned FormatMaxPadding, bool TruncateZero) const {
@@ -4311,6 +4576,961 @@ void IEEEFloat::toString(SmallVectorImpl<char> &Str, unsigned FormatPrecision,
 
   for (; I != NDigits; ++I)
     Str.push_back(buffer[NDigits-I-1]);
+}
+
+uint32_t DFPFloat::maxFormatDigits() const {
+  if (semantics == &semDFP32)
+    return 7;
+  if (semantics == &semDFP64)
+    return 16;
+  if (semantics == &semDFP128)
+    return 34;
+  
+  llvm_unreachable("Unknow DFP semantics");
+}
+
+uint32_t DFPFloat::decimalExponentBias() const {
+  if (semantics == &semDFP32)
+    return 101;
+  if (semantics == &semDFP64)
+    return 398;
+  if (semantics == &semDFP128)
+    return 6176;
+
+  llvm_unreachable("Unknow DFP semantics");
+}
+
+uint32_t DFPFloat::decimalMaxExponent() const {
+  if (semantics == &semDFP32)
+    return 191;
+  if (semantics == &semDFP64)
+    return 767;
+  if (semantics == &semDFP128)
+    return 12287;
+
+  llvm_unreachable("Unknow DFP semantics");
+}
+
+void DFPFloat::mul64By64To128(DFPFloat::Two64Wrapped &p, uint64_t cx, uint64_t cy) const {
+  uint64_t cxh = cx >> 32;;
+  uint64_t cxl = static_cast<uint32_t>(cx);
+  uint64_t cyh = cy >> 32;
+  uint64_t cyl = static_cast<uint64_t>(cy);
+  uint64_t pm  = cxh * cyl;
+  uint64_t ph  = cxh * cyh;
+  uint64_t pl  = cxl * cyl;
+  uint64_t pm2 = cxl * cyh;
+  
+  ph += pm>>32;
+  pm = static_cast<uint32_t>(pm) + pm2 + (pl>>32);
+
+  p.w[1] = ph + (pm >> 32);
+  p.w[0] = (pm<<32) + static_cast<uint32_t>(pl);
+}
+
+uint64_t DFPFloat::addCarryOut(uint64_t &s, uint64_t x, uint64_t y) const {
+  uint64_t x1 = x;
+  s = x + y;
+  return s<x1 ? 1 : 0;
+}
+
+void DFPFloat::unpackBID32(uint32_t x, uint32_t &sgn, uint32_t &exp, uint32_t &coeff, bool &isInf, bool &isSNaN, bool &isNaN) const {
+  uint32_t tmp;
+
+  sgn = x & 0x80000000;
+
+  constexpr static uint32_t special_encoding_mask = 0x60000000u;
+
+  if ((x & special_encoding_mask) == special_encoding_mask) {
+    // Infinity and NaN handling
+    if ((x & 0x78000000u) == 0x78000000) {
+      coeff = x & 0xFE0FFFFFu;
+      isSNaN = true;
+      if ((x & 0x000FFFFFu) >= 1000000) {
+        isNaN = true;
+        isSNaN = false;
+        coeff = x & 0xFE000000u;
+      }
+      if ((x & 0x7C000000u) == 0x78000000u) {
+        isInf = true;
+        isSNaN = false;
+        coeff = x & 0xF8000000u;
+      }
+
+      exp = 0;
+      return;
+    }
+
+    coeff = (x & 0x001FFFFFu) | 0x00800000u;
+
+    if (coeff >= 10000000)
+      coeff = 0;
+     
+    tmp = x >> 21;
+    exp = tmp & 0xFF;
+    return;
+  }
+  tmp = x >> 23;
+  exp = tmp & 0xFF;
+  coeff = x & 0x007FFFFFu;
+}
+
+uint32_t DFPFloat::packBID32(uint32_t sgn, int32_t exp, uint64_t coeff, bool negativeExp, bool rounded, roundingMode rounding_mode) const {
+  Two64Wrapped q{};
+  uint64_t c64 = 0;
+  int extra_digits = 0;
+  int amount = 0;
+  int amount2 = 0;
+  int roundingModeToIndex = 0;
+  
+  // FIXME handle status flags
+
+  if (coeff > 9999999ul) {
+    ++exp;
+    coeff = 1000000ul;
+  }
+
+  // Check for underflow or overflow
+  if (static_cast<uint32_t>(exp) > decimalMaxExponent() ) {
+    if (exp < 0) {
+      // Underflow case
+      if ((exp + maxFormatDigits()) < 0) {
+      // FIXME set status flags
+
+        switch (rounding_mode) {
+          case rmTowardNegative:
+            roundingModeToIndex = 1;
+            if (sgn)
+              return 0x80000001;
+            break;
+          case rmTowardPositive:
+            roundingModeToIndex = 2;
+            if (sgn)
+              return 1;
+            break;
+          case rmNearestTiesToEven:
+          case rmNearestTiesToAway:
+            roundingModeToIndex = 0;
+          case rmTowardZero:
+            if (sgn && (roundingModeToIndex -1) < 2)
+              roundingModeToIndex = 3 - roundingModeToIndex;
+          default:
+          break;
+        }
+        return sgn;
+      }
+
+      // 10*coeff
+      coeff = (coeff << 3) + (coeff << 1);
+
+      if (negativeExp && rounded)
+        coeff |= 1;
+
+      extra_digits = 1 - exp;
+      coeff += bid_round_const_table[roundingModeToIndex][extra_digits];
+      mul64By64To128(q, coeff, bid_reciprocals10_64[extra_digits]);
+      amount = bid_short_recip_scale[extra_digits];
+
+      c64 = q.w[1] >> amount;
+
+      if (rounding_mode == rmNearestTiesToEven) {
+        if (c64 & 1) {
+          // check whether fractional part of initial_P/10^extraa_digits is exactly .5
+
+          // get remainder
+          amount2 = 64 - amount;
+          uint64_t remainder_h = -1;
+          remainder_h >>= amount2;
+          remainder_h = remainder_h & q.w[1];
+
+          if (remainder_h && (q.w[0] < bid_reciprocals10_64[extra_digits]))
+            --c64;
+        }
+      }
+
+      // FIXME set status flags
+
+      return sgn | (uint32_t)c64;
+    }
+
+    if (!negativeExp && !coeff && (exp > decimalMaxExponent()))
+        exp = decimalMaxExponent();
+    
+    while (coeff < 1000000 && exp > decimalMaxExponent()) {
+      coeff = (coeff << 3) + (coeff << 1);
+      --exp;
+    }
+
+    if (static_cast<uint32_t>(exp) > decimalMaxExponent()) {
+      // FIXME set status flags
+
+      // overflow
+      uint32_t r = sgn | 0x78000000ul;
+      switch (rounding_mode) {
+        case rmTowardNegative:
+          if (!sgn)
+            r = 0x77F8967Ful; // Largest bid32 
+          break;
+        case rmTowardZero:
+          r = sgn | 0x77F8967Ful;
+          break;
+        case rmTowardPositive:
+          if (sgn)
+            r = sgn | 0x77F8967Ful;
+          break;
+        case rmNearestTiesToEven:
+        case rmNearestTiesToAway:
+        default:
+          break;
+      }
+      return r;
+    }
+  }
+
+  uint32_t mask = 1 << 23;
+  uint32_t r = 0;
+
+  if (coeff < mask) {
+    r = exp;
+    r <<= 23;
+    r |= (static_cast<uint32_t>(coeff) | sgn);
+    return r;
+  }
+
+  r = exp;
+  r <<= 21;
+  r |= sgn | 0x60000000ul;
+  mask = (1 << 21) - 1;
+  r |= static_cast<uint32_t>(coeff) & mask;
+
+  return r;
+}
+
+template <const fltSemantics &S>
+void DFPFloat::initFromDFP32APInt(const APInt &api)  {
+  assert(semantics == &S);
+
+  std::array<integerPart, 1> mysignificand;
+  std::copy_n(api.getRawData(), mysignificand.size(), mysignificand.begin());
+
+  // We assume the last word holds the sign bit, the exponent, and potentially
+  // some of the trailing significand field.
+  uint64_t last_word = api.getRawData()[0];
+
+  integerPart exponentTopBitsMask = 0x1FFFFFFF;
+ 
+  initialize(&S);
+  assert(partCount() == mysignificand.size());
+  
+  uint32_t sgn=0;
+  uint32_t coeff=0;
+  uint32_t exp_calc=0;
+  bool isInf = false;
+  bool isNaN = false;
+  bool isSNaN = false;
+  unpackBID32(last_word, sgn, exp_calc, coeff, isInf, isSNaN, isNaN);
+  *significandParts() = coeff;
+  exponent = exp_calc;
+  sign = sgn ? 1 : 0;
+
+  bool all_zero_significand =
+      llvm::all_of(mysignificand, [](integerPart bits) { return bits == 0; });
+
+  bool is_zero = (exp_calc & exponentTopBitsMask) == 0 && all_zero_significand;
+
+  if (isNaN || isSNaN) {
+    category = fcNaN;
+    exponent = ::exponentNaN(S);
+    std::copy_n(mysignificand.begin(), mysignificand.size(),
+                significandParts());
+    return;
+  }
+
+  if (is_zero) {
+    makeZero(sign);
+    return;
+  }
+
+  if (isInf) {
+     makeInf(sign, false);
+     return;
+  }
+
+  category = fcNormal;
+}
+
+template <const fltSemantics &S>
+void DFPFloat::initFromDFP64APInt(const APInt &api)  {
+  assert(semantics == &S);
+
+}
+
+template <const fltSemantics &S>
+void DFPFloat::initFromDFP128APInt(const APInt &api)  {
+  assert(semantics == &S);
+
+}
+
+void DFPFloat::initFromAPInt(const fltSemantics *Sem, const APInt &api) {
+  assert(api.getBitWidth() == Sem->sizeInBits);
+  if (Sem == &semDFP32)
+    return initFromDFP32APInt<semDFP32>(api);
+  if (Sem == &semDFP64)
+    return initFromDFP64APInt<semDFP64>(api);
+  if (Sem == &semDFP128)
+    return initFromDFP128APInt<semDFP128>(api);
+}
+
+DFPFloat::DFPFloat(const fltSemantics &Sem, const APInt &API) {
+  semantics = &Sem;
+   initFromAPInt(&Sem, API);
+}
+
+DFPFloat::DFPFloat(const fltSemantics &ourSemantics) {
+  initialize(&ourSemantics);
+  makeZero(false);
+}
+
+DFPFloat::DFPFloat(const fltSemantics &ourSemantics, uninitializedTag tag)
+    : DFPFloat(ourSemantics) {}
+
+void DFPFloat::initialize(const fltSemantics *ourSemantics) {
+  semantics = ourSemantics;
+
+  if (partCount() > 1)
+    significand.parts = new integerPart[partCount()];
+}
+
+APInt DFPFloat::bitcastToAPInt() const {
+  if (semantics == (const llvm::fltSemantics*)&semDFP32)
+    return convertDFPToAPInt<semDFP32>();
+
+  if (semantics == (const llvm::fltSemantics *)&semDFP64)
+    return convertDFPToAPInt<semDFP64>();
+
+  if (semantics == (const llvm::fltSemantics*)&semDFP128)
+   return convertDFPToAPInt<semDFP128>();
+}
+
+template <const fltSemantics &S>
+APInt DFPFloat::convertDFPToAPInt() const {
+  assert(semantics == &S);
+
+  constexpr unsigned int num_words = S.sizeInBits / 32;
+
+  uint64_t myexponent = exponent;
+  std::array<integerPart, num_words>
+      mysignificand;
+  std::array<uint64_t, num_words> words{};
+
+  if (category == fcZero) {
+    myexponent = 0x00000000 ;
+    mysignificand.fill(0);
+  } else if (category == fcInfinity) {
+    myexponent = 0x78000000;
+    mysignificand.fill(0);
+  } else if (category == fcNaN) {
+    myexponent = 0x7C000000;
+    std::copy_n(significandParts(), mysignificand.size(),
+                mysignificand.begin());
+  } else {
+     std::copy_n(significandParts(), mysignificand.size(),
+                mysignificand.begin());
+
+    uint32_t mask = 1 << 23;
+    uint32_t r = 0;
+    uint32_t sgn = sign ? 0x80000000u : 0;
+
+    if (mysignificand[0] < mask) {
+      r = myexponent;
+      r <<= 23;
+      r |= (static_cast<uint32_t>(mysignificand[0]) | sgn);
+    } else {
+      r = myexponent;
+      r <<= 21;
+      r |= sgn | 0x60000000ul;
+      mask = (1 << 21) - 1;
+      r |= static_cast<uint32_t>(mysignificand[0]) & mask;
+    }
+
+    words[0] = r;
+  }
+  
+  if (category != fcNormal) {
+    auto words_iter =
+       std::copy_n(mysignificand.begin(), mysignificand.size(), words.begin());
+  
+     constexpr size_t last_word = 0;
+     uint64_t shifted_sign = static_cast<uint64_t>(sign & 1)
+                             << ((S.sizeInBits - 1) % 64);
+     words[last_word] |= shifted_sign;
+     uint64_t shifted_exponent = myexponent; 
+     words[last_word] |= shifted_exponent;
+  }
+  
+  if constexpr (num_words == 1) {
+    return APInt(S.sizeInBits, words[0]);
+  }
+  return APInt(S.sizeInBits, words);
+}
+
+void DFPFloat::makeZero(bool Negative) {
+  category = fcZero;
+  sign = Negative;
+  
+  exponent = 0;
+  APInt::tcSet(significandParts(), 0, partCount());
+}
+
+void DFPFloat::makeZeroInternalDFP32(bool Neg, int right_of_radix_leading_zero) {
+  unsigned sign_mask = 0;
+
+  if (Neg)
+    sign_mask = 0x80000000u;
+
+  integerPart *significand = significandParts();
+  unsigned numParts = partCount();
+  *significand = sign_mask | (right_of_radix_leading_zero << 23);
+  exponent = 0;
+  category = fcZero;
+}
+
+void DFPFloat::makeZeroInternalDFP64(bool Neg, int right_of_radix_leading_zero) {
+  assert(false && "NotImplemented");
+
+  exponent = 0;
+  category = fcZero;
+}
+
+void DFPFloat::makeZeroInternalDFP128(bool Neg, int right_of_radix_leading_zero) {
+  assert(false && "NotImplemented");
+
+  exponent = 0;
+  category = fcZero;
+}
+
+
+void DFPFloat::makeNaN(bool SNaN, bool Negative, const APInt *fill) {
+  category = fcNaN;
+  sign = Negative;
+
+  if (SNaN)
+    exponent = 0x7E000000;
+  else
+    exponent = 0x7C000000;
+
+  integerPart *significand = significandParts();
+  unsigned numParts = partCount();
+  
+  APInt::tcSet(significand, 0, numParts);
+}
+
+void DFPFloat::makeInf(bool Negative, bool explictPlus) {
+  category = fcInfinity;
+  sign = Negative;
+  
+  if (Negative)
+    exponent = 0xF8000000;
+  else if (explictPlus)
+    exponent = 0x78000000;
+  else
+    exponent = 0x7C000000;
+
+  APInt::tcSet(significandParts(), 0, partCount());
+}
+  
+unsigned int DFPFloat::partCount() const {
+  return partCountForBits(semantics->precision + 1);
+}
+
+const DFPFloat::integerPart *DFPFloat::significandParts() const {
+  return const_cast<DFPFloat *>(this)->significandParts();
+}
+
+DFPFloat::integerPart *DFPFloat::significandParts()  {
+  if (partCount() > 1)
+    return significand.parts;
+  else
+    return &significand.part;
+}
+
+bool DFPFloat::convertFromStringSpecials(StringRef str) {
+  const size_t MIN_NAME_SIZE = 3;
+
+  if (str.size() < MIN_NAME_SIZE)
+    return false;
+
+  bool explicitPlus = str.front() == '+';
+  bool isMinus = str.front() == '-';
+
+  if (explicitPlus || isMinus)
+    str = str.drop_front();
+
+  if (str.equals_insensitive("inf") || str.equals_insensitive("INFINITY")) {
+    makeInf(isMinus, explicitPlus);
+    return true;
+  }
+
+  // If we have a 's' (or 'S') prefix, then this is a Signaling NaN.
+  bool IsSignaling = str.front() == 's' || str.front() == 'S';
+  if (IsSignaling) {
+    str = str.drop_front();
+    if (str.size() < MIN_NAME_SIZE)
+      return false;
+  }
+
+  if (str.starts_with_insensitive("nan")) {
+    str = str.drop_front(3);
+
+    if (str.empty()) {
+      makeNaN(IsSignaling, isMinus);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+
+Expected<IEEEFloat::opStatus>
+DFPFloat::convertFromStringDFP32(StringRef str, roundingMode rounding_mode) {
+  if (str.empty())
+    return createError("Invalid string length");
+
+  // Handle special cases.
+  if (convertFromStringSpecials(str))
+    return opOK;
+  
+  bool explicitPlus = str.front() == '+';
+  bool isMinus = str.front() == '-';
+  unsigned sign_mask = 0;
+
+  if (isMinus)
+    sign_mask = 0x80000000u;
+
+  if (explicitPlus || isMinus)
+    str = str.drop_front();
+
+  // Verify that the we start with a decimal point or decimal digit
+  if (str.front() != '.' && (str.front() < '0' && str.front() > '9')) {
+    makeNaN( /*SNaN=*/false, isMinus);
+    return createError("Invalid DFP format");
+  }
+
+  unsigned exponent_bias = decimalExponentBias();
+  int32_t exp = 0;
+  int add_exponent = 0;
+  int decimal_exp_scale = 0;
+  int right_of_radix_leading_zero = 0;
+  unsigned radix_pt_encoding = 0;
+  unsigned num_digits = 0;
+  uint64_t coefficient_calc = 0;
+  bool rounded = false;
+  bool rounded_up = false;
+  bool midpoint = false;
+  bool signed_exponent = false;
+
+  // Detect and remove leading zeros
+  if (str.front() == '0' || str.front() == '.') {
+     if (str.front() == '.') {
+       radix_pt_encoding = 1;
+       str = str.drop_front();
+     }
+
+      while (!str.empty() && str.front() == '0') {
+        str = str.drop_front();
+
+        if (str.empty())
+          continue;
+
+        // Count the leading zero after radix point e.g.
+        // 0.000000000000001
+        if (radix_pt_encoding)
+          right_of_radix_leading_zero++;
+
+        // Check we have not seen a radix point yet
+        if (str.front() == '.') {
+          // Error we have two radix points 
+          if (radix_pt_encoding) {
+            makeNaN( /*SNaN=*/false, isMinus);
+            return createError("Invalid DFP format, two radix points");
+          }
+          
+          radix_pt_encoding = 1;
+          str = str.drop_front();
+
+          // If we just hit the radix point and we don't hae more digits
+          // we are zero.
+          if (str.empty()) {
+             right_of_radix_leading_zero = exponent_bias - right_of_radix_leading_zero;
+            
+             if (right_of_radix_leading_zero < 0)
+               right_of_radix_leading_zero = 0;
+
+             makeZeroInternalDFP32(isMinus,right_of_radix_leading_zero);
+             return opOK;
+          }
+        } else if (str.empty()) {
+          right_of_radix_leading_zero = exponent_bias - right_of_radix_leading_zero;
+            
+          if (right_of_radix_leading_zero < 0)
+            right_of_radix_leading_zero = 0;
+          
+          makeZeroInternalDFP32(isMinus,right_of_radix_leading_zero);
+          return opOK;
+        }
+      }
+  }
+
+  num_digits = 0;
+  while (!str.empty() && ((str.front() >= '0' && str.front() <= '9') || str.front() == '.')) {
+    if (str.front() == '.') {
+      if (radix_pt_encoding) {
+        makeNaN( /*SNaN=*/false, isMinus);
+        return createError("Invalid DFP format, two radix points");
+      }
+
+      radix_pt_encoding = 1;
+      str = str.drop_front();
+      continue;
+    }
+
+    decimal_exp_scale += radix_pt_encoding;
+    ++num_digits;
+    
+    if (num_digits <= 7) {
+      coefficient_calc = (coefficient_calc << 1) + (coefficient_calc << 3);
+      coefficient_calc += static_cast<uint64_t>(str.front() - '0');
+    } else if (num_digits == 8) {
+      switch (rounding_mode) {
+        case RoundingMode::NearestTiesToEven:
+          midpoint = (str.front() == '5' && !(coefficient_calc & 1)) ? true : false;
+          
+          if (str.front() > '5' || (str.front() == '5' && (coefficient_calc & 1))) {
+            coefficient_calc++;
+            rounded_up = true;
+          } else {
+            if (coefficient_calc == 10000000ul) {
+              coefficient_calc = 1000000ul;
+              add_exponent = 1;
+            }
+          }
+          break;
+        case RoundingMode::TowardNegative:
+        case RoundingMode::TowardZero:
+          if (isMinus) {
+            coefficient_calc++;
+            rounded_up = true;
+          }
+          break;
+        case RoundingMode::TowardPositive:
+          if (!isMinus) {
+            coefficient_calc++;
+            rounded_up = true;
+          }
+          break;
+        case RoundingMode::NearestTiesToAway:
+        if (str.front() >= '5') {
+            coefficient_calc++;
+            rounded_up = true;
+          }
+          break;
+      }
+
+      if (str.front() > '0')
+        rounded = true;
+
+      ++add_exponent;
+    } else {
+      ++add_exponent;
+
+      if (midpoint && str.front() > '0') {
+        ++coefficient_calc;
+        midpoint = false;
+        rounded_up = true;
+      }
+
+      if (str.front() > '0')
+        rounded = true;
+    }
+
+    str = str.drop_front();
+  }
+
+  add_exponent -= (decimal_exp_scale + right_of_radix_leading_zero);
+
+  if (str.empty()) {
+    //FIXME handle setting status flags
+
+    uint32_t packedResult = packBID32(isMinus, add_exponent + decimalExponentBias(), coefficient_calc, /*negativeExp=*/false, /*rounded=*/false, rounding_mode);
+    uint32_t sgn=0;
+    uint32_t coeff=0;
+    uint32_t exp_calc=0;
+    bool isInf = false;
+    bool isNaN = false;
+    bool isSNaN = false;
+    unpackBID32(packedResult, sgn, exp_calc, coeff, isInf, isSNaN, isNaN);
+    *significandParts() = coeff;
+    exponent = exp_calc;
+    sign = isMinus;
+    category = fcNormal;
+    return opOK;
+  }
+
+  if (str.front() != 'E' && str.front() != 'e') {
+     makeNaN( /*SNaN=*/false, isMinus);
+     return opInvalidOp;
+  }
+
+  str = str.drop_front();
+
+  if (str.front() == '-')
+   signed_exponent = true;
+
+  if (str.front() == '-' || str.front() == '+')
+    str = str.drop_front();
+
+  if (str.empty() || str.front() < '0' || str.front() > '9') {
+     makeNaN( /*SNaN=*/false, isMinus);
+     return opInvalidOp;
+  }
+
+  while (!str.empty() && (str.front() >= '0') && (str.front() <= '9')) {
+    if (exp < (1<<20)) {
+      exp = (exp << 1) + (exp << 3);
+      exp += static_cast<int>(str.front() - '0');
+    }
+
+    str = str.drop_front();
+  }
+
+  if (!str.empty()) {
+    makeNaN( /*SNaN=*/false, isMinus);
+    return opInvalidOp;
+  }
+
+  // FIXME handle setting status flags
+
+  if (signed_exponent)
+    exp = -exp;
+
+  exp += add_exponent + exponent_bias;
+
+  if (exp < 0) {
+    if (rounded_up)
+      --coefficient_calc;
+
+    uint32_t packedResult = packBID32(isMinus, exp, coefficient_calc, /*negativeExp=*/false, /*rounded=*/rounded, rounding_mode);
+    uint32_t sgn=0;
+    uint32_t coeff=0;
+    uint32_t exp_calc=0;
+    bool isInf = false;
+    bool isNaN = false;
+    bool isSNaN = false;
+    
+    unpackBID32(packedResult, sgn, exp_calc, coeff, isInf, isSNaN, isNaN);
+    *significandParts() = coeff;
+    exponent = exp_calc;
+    sign = isMinus;
+    category = fcNormal;
+  }
+
+  uint32_t packedResult = packBID32(isMinus, exp, coefficient_calc, /*negativeExp=*/false, /*rounded=*/false, rounding_mode);
+  uint32_t sgn=0;
+  uint32_t coeff=0;
+  uint32_t exp_calc=0;
+  bool isInf = false;
+  bool isNaN = false;
+  bool isSNaN = false;
+    
+  unpackBID32(packedResult, sgn, exp_calc, coeff, isInf, isSNaN, isNaN);
+  *significandParts() = coeff;
+  exponent = exp_calc;
+  sign = isMinus;
+  category = fcNormal;
+
+  return opOK;
+}
+
+Expected<IEEEFloat::opStatus>
+DFPFloat::convertFromStringDFP64(StringRef str, roundingMode rounding_mode) {
+  assert(false && "Not implemented!");
+}
+
+Expected<IEEEFloat::opStatus>
+DFPFloat::convertFromStringDFP128(StringRef str, roundingMode rounding_mode) {
+  assert(false && "Not implemented!");
+}
+
+
+Expected<IEEEFloat::opStatus>
+DFPFloat::convertFromString(StringRef str, roundingMode rounding_mode) {
+ if (semantics == (const llvm::fltSemantics*)&semDFP32)
+    return convertFromStringDFP32(str, rounding_mode);
+
+  if (semantics == (const llvm::fltSemantics *)&semDFP64)
+    return convertFromStringDFP64(str, rounding_mode);
+
+  if (semantics == (const llvm::fltSemantics*)&semDFP128)
+   return convertFromStringDFP128(str, rounding_mode);
+}
+
+void DFPFloat::toStringDFP32(SmallVectorImpl<char> &Str, unsigned FormatPrecision,
+                         unsigned FormatMaxPadding, bool TruncateZero) const {
+  switch (category) {
+  case fcInfinity:
+    if (isNegative())
+      return append(Str, "-Inf");
+    else
+      return append(Str, "+Inf");
+
+  case fcNaN: return append(Str, "NaN");
+
+  case fcZero:
+    assert(!isNegative());
+
+    Str.push_back('0');
+    return;
+
+  case fcNormal:
+    break;
+  }
+
+  if (isNegative())
+    Str.push_back('-');
+
+  // Assuming BID format for now and will have to add DPD support
+ 
+  int exp = exponent;
+  APInt significand(
+      semantics->sizeInBits,
+      ArrayRef(significandParts(), partCountForBits(semantics->precision)));
+  
+  auto coefficient = significand.getZExtValue();
+  unsigned long CT = 0;
+  int digit;
+
+  // Handle _DEcimal32
+  if (semantics->sizeInBits == 32 ) {
+     if (coefficient >= 1000000) {
+        // Obtain lower six bits
+        CT = coefficient * 0x431BDE83ull;
+        CT >>= 32;
+        digit = CT >> (50-32);
+        Str.push_back(digit + '0');
+        
+        coefficient -= digit * 1000000;
+
+        CT = coefficient * 0x20C49BA6ull;
+        CT >>= 32;
+        digit = CT >> (39-32);
+
+        Str.push_back(bid_midi_tbl[digit][0]);
+        Str.push_back(bid_midi_tbl[digit][1]);
+        Str.push_back(bid_midi_tbl[digit][2]);
+
+        digit = coefficient - digit*1000;
+
+        Str.push_back(bid_midi_tbl[digit][0]);
+        Str.push_back(bid_midi_tbl[digit][1]);
+        Str.push_back(bid_midi_tbl[digit][2]);
+
+     } else if (coefficient >= 1000) {
+        CT = coefficient * 0x20C49BA6ull;
+        CT >>= 32;
+        digit = CT >> (39-32);
+        bool ignoreZero = false;
+        bool ignoreOne = false;
+
+        if (bid_midi_tbl[digit][0] == '0')
+          ignoreZero = true;
+        if (bid_midi_tbl[digit][1] == '0' || !ignoreZero)
+          ignoreOne = true;
+
+        if (!ignoreZero)
+          Str.push_back(bid_midi_tbl[digit][0]); 
+        if (!ignoreOne)
+          Str.push_back(bid_midi_tbl[digit][1]);
+        
+        Str.push_back(bid_midi_tbl[digit][2]);
+
+        digit = coefficient - digit*1000;
+
+        Str.push_back(bid_midi_tbl[digit][0]);
+        Str.push_back(bid_midi_tbl[digit][1]);
+        Str.push_back(bid_midi_tbl[digit][2]);
+
+     } else {
+       digit = coefficient;
+
+       bool ignoreZero = false;
+       bool ignoreOne = false;
+
+       if (bid_midi_tbl[digit][0] == '0')
+         ignoreZero = true;
+       if (bid_midi_tbl[digit][1] == '0' || !ignoreZero)
+         ignoreOne = true;
+
+       if (!ignoreZero)
+         Str.push_back(bid_midi_tbl[digit][0]); 
+       if (!ignoreOne)
+         Str.push_back(bid_midi_tbl[digit][1]);
+        
+       Str.push_back(bid_midi_tbl[digit][2]);
+     }
+  } else if (semantics->sizeInBits == 64 ) {
+
+  } else {
+    assert(semantics->sizeInBits == 128);
+  }
+
+  Str.push_back('E');
+
+  exp -= (int32_t)decimalExponentBias();
+
+  if (exp < 0) {
+    Str.push_back('-');
+    exp = -exp;
+  } else {
+    Str.push_back('+');
+  }
+
+   bool ignoreZero = false;
+   bool ignoreOne = false;
+
+  if (bid_midi_tbl[exp][0] == '0')
+    ignoreZero = true;
+  if (bid_midi_tbl[exp][1] == '0' || !ignoreZero)
+    ignoreOne = true;
+  
+  if (!ignoreZero)
+    Str.push_back(bid_midi_tbl[exp][0]); 
+  if (!ignoreOne)
+    Str.push_back(bid_midi_tbl[exp][1]);
+  
+  Str.push_back(bid_midi_tbl[exp][2]);
+}
+
+void DFPFloat::toStringDFP64(SmallVectorImpl<char> &Str, unsigned FormatPrecision,
+                         unsigned FormatMaxPadding, bool TruncateZero) const {
+  assert(false && "Not Implemented");
+}
+
+void DFPFloat::toStringDFP128(SmallVectorImpl<char> &Str, unsigned FormatPrecision,
+                         unsigned FormatMaxPadding, bool TruncateZero) const {
+  assert(false && "Not Implemented");
+}
+
+void DFPFloat::toString(SmallVectorImpl<char> &Str, unsigned FormatPrecision,
+                         unsigned FormatMaxPadding, bool TruncateZero) const {
+  if (semantics == (const llvm::fltSemantics*)&semDFP32)
+    toStringDFP32(Str, FormatPrecision, FormatMaxPadding, TruncateZero);
+
+  if (semantics == (const llvm::fltSemantics *)&semDFP64)
+    toStringDFP64(Str, FormatPrecision, FormatMaxPadding, TruncateZero);
+
+  if (semantics == (const llvm::fltSemantics*)&semDFP128)
+   toStringDFP128(Str, FormatPrecision, FormatMaxPadding, TruncateZero);
 }
 
 bool IEEEFloat::getExactInverse(APFloat *inv) const {
@@ -5265,6 +6485,9 @@ APFloat::opStatus APFloat::convert(const fltSemantics &ToSemantics,
     *this = APFloat(std::move(getIEEE()), ToSemantics);
     return Ret;
   }
+  if (usesLayout<DFPFloat>(getSemantics()) &&
+      usesLayout<DFPFloat>(ToSemantics))
+    return U.DFP.convert(ToSemantics, RM, losesInfo);
   llvm_unreachable("Unexpected semantics");
 }
 


### PR DESCRIPTION
This PR implements the parsing and printing of `Decimal32` literals. 

A large part of the work was weaving through the existing `APFloat` code paths for parsing and printing of literals. The rest of the work was generalizing it so that we have paths for 32, 64 and 128. 

Since the delta was getting large I limited this change to only dealing with `Decimal32` and will implement similar code for `Decimal64` and `Decimal128` in a follow-up PR.

The parsing and printing code is port of the code from the Intel DFP library. I imported the tables as they were. I don't think there is an obvious optimization around these and it would likely be a lot of work and so I feel we should leave these as are for the first implementation and if we find issue we can revisit at that time.
