### PR TITLE
[SYCL-Upstreaming] Fix a crash

### DIFF
--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -12936,6 +12936,11 @@ ExprResult TreeTransform<Derived>::TransformSYCLUniqueStableNameExpr(
 template <typename Derived>
 StmtResult TreeTransform<Derived>::TransformUnresolvedSYCLKernelCallStmt(
     UnresolvedSYCLKernelCallStmt *S) {
+  auto *FD = cast<FunctionDecl>(SemaRef.CurContext);
+  const auto *SKEPAttr = FD->getAttr<SYCLKernelEntryPointAttr>();
+  if (!SKEPAttr || SKEPAttr->isInvalidAttr())
+    return StmtError();
+
   ExprResult IdExpr = getDerived().TransformExpr(S->getKernelLaunchIdExpr());
 
   if (IdExpr.isInvalid())

--- a/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-kernel-name.cpp
+++ b/clang/test/SemaSYCL/sycl-kernel-entry-point-attr-kernel-name.cpp
@@ -124,3 +124,25 @@ struct B19 {
 };
 // expected-note@+1 {{in instantiation of template class 'B19<int>' requested here}}
 B19<int> b19;
+
+struct auto_name;
+
+// expected-error@+4 {{the 'clang::sycl_kernel_entry_point' kernel name argument conflicts with a previous declaration}}
+// expected-note@+3 {{previous declaration is here}}
+template <typename KernelName, typename KernelType>
+[[clang::sycl_kernel_entry_point(KernelName)]]
+void __kernel_single_task(const KernelType KernelFunc) {
+  KernelFunc();
+}
+
+template <typename KernelType, typename KernelName = auto_name>
+void pf(KernelType K) {
+  // expected-note@+1 {{requested here}}
+  __kernel_single_task<KernelName>(K);
+}
+
+void foo() {
+  pf([](){});
+  // expected-note@+1 {{requested here}}
+  pf([](){});
+}


### PR DESCRIPTION
In case a function with skep attribute is instantiated two times with the same kernel name the attribute is invalid due to the conflicting name. Make sure to exit from instantiation of UnresolvedSYCLKernelCallStmt in this case.