### PR TITLE
[SYCL-Upstreaming] Fix a crash when an argument of skep function is not trivially-copyable

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -511,7 +511,7 @@ StmtResult BuildSYCLKernelLaunchStmt(Sema &SemaRef,
     if (LaunchResult.isInvalid())
       return StmtError();
 
-    Stmts.push_back(LaunchResult.get());
+    Stmts.push_back(SemaRef.MaybeCreateExprWithCleanups(LaunchResult).get());
   }
 
   return CompoundStmt::Create(SemaRef.getASTContext(), Stmts,


### PR DESCRIPTION
device-copyable doesn't mean trivially-copyable, so we may encounter arguments that need cleanup. Adds test that verifies presence of the dtor call in the synthesized code.